### PR TITLE
Further restructuring

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,11 @@ numpydoc_show_class_members = False
 intersphinx_mapping = {
     "h5py": ("https://docs.h5py.org/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable", None),
+    "pathlib": ("https://docs.python.org/3/library/pathlib.html", None),
     "pooch": ("https://www.fatiando.org/pooch/latest", None),
     "pyfar": ("https://pyfar.readthedocs.io/en/stable", None),
     "python": ("https://docs.python.org/3/", None),
+    "rich": ("https://rich.readthedocs.io/en/stable/", None),
+    "sofar": ("https://sofar.readthedocs.io/en/latest/", None),
+    "typer": ("https://typer.tiangolo.com/", None),
 }

--- a/src/irdl/base.py
+++ b/src/irdl/base.py
@@ -58,8 +58,6 @@ class BaseDataset(ABC):
     # Default docstring prefix for all get() classmethods
     _get_doc_prefix = """Download {name} dataset.
 
-DOI: {doi}
-
 Parameters
 ----------
 cache_dir : str
@@ -77,9 +75,25 @@ output_format : str
         if hasattr(cls, "get") and hasattr(cls, "name") and hasattr(cls, "doi"):
             # Get the underlying function of the classmethod
             get_func = cls.get.__func__
+            # Get the first line of the class docstring for the summary
+            class_doc = cls.__doc__ or ""
+            doc_lines = class_doc.strip().split("\n") if class_doc.strip() else []
+            summary_line = doc_lines[0] if doc_lines else ""
+            # Construct DOI line from cls.doi attribute
+            doi_url = f"https://doi.org/{cls.doi}"
+            doi_cli_line = f"DOI: {doi_url}"
             # Format prefix with class attributes
             prefix = BaseDataset._get_doc_prefix.format(name=cls.name, doi=cls.doi)
-            # Get subclass-specific docstring
+            # If class has a docstring with a summary, replace the first line of prefix
+            if summary_line:
+                # Split prefix into lines and replace the first line
+                prefix_lines = prefix.split("\n")
+                prefix_lines[0] = summary_line
+                # Insert DOI line after the summary
+                prefix_lines.insert(1, "")
+                prefix_lines.insert(2, doi_cli_line)
+                prefix = "\n".join(prefix_lines)
+            # Get subclass-specific docstring (from the base class _get method)
             suffix = get_func.__doc__ or ""
             # Combine: prefix + suffix
             full_doc = prefix

--- a/src/irdl/base.py
+++ b/src/irdl/base.py
@@ -8,14 +8,10 @@ logic for parameter validation, file retrieval, ingestion, and output naming.
 from pathlib import Path
 from typing import Any
 
+import h5py as h5
 import numpy as np
 import pyfar as pf
 import sofar as sf
-import h5py as h5
-import shutil
-
-# Import CACHE_DIR from downloader to maintain consistency
-from irdl.downloader import CACHE_DIR
 
 
 class BaseDataset:
@@ -45,7 +41,7 @@ class BaseDataset:
 
     name: str
     doi: str
-    raw_format: str 
+    raw_format: str
 
     # Default docstring prefix for all get() classmethods
     _get_doc_prefix = """Download {name} dataset.
@@ -63,28 +59,25 @@ output_format : str
 """
 
     def __init_subclass__(cls, **kwargs):
+        """Compose the get() docstring when a subclass is defined."""
         super().__init_subclass__(**kwargs)
         # Automatically compose docstrings for get() classmethod
-        if hasattr(cls, 'get') and hasattr(cls, 'name') and hasattr(cls, 'doi'):
+        if hasattr(cls, "get") and hasattr(cls, "name") and hasattr(cls, "doi"):
             # Get the underlying function of the classmethod
             get_func = cls.get.__func__
             # Format prefix with class attributes
-            prefix = BaseDataset._get_doc_prefix.format(
-                name=cls.name,
-                doi=cls.doi
-            )
+            prefix = BaseDataset._get_doc_prefix.format(name=cls.name, doi=cls.doi)
             # Get subclass-specific docstring
             suffix = get_func.__doc__ or ""
             # Combine: prefix + suffix
             full_doc = prefix
             if suffix:
-                if not full_doc.endswith('\n\n'):
-                    full_doc += '\n\n'
+                if not full_doc.endswith("\n\n"):
+                    full_doc += "\n\n"
                 full_doc += suffix
             get_func.__doc__ = full_doc
 
-    def _get(self, *, cache_dir: str, export_dir: str | None,
-             output_format: str, **dataset_kwargs) -> Any:
+    def _get(self, *, cache_dir: str, export_dir: str | None, output_format: str, **dataset_kwargs) -> Any:
         """Execute the full dataset retrieval pipeline.
 
         Validates parameters, returns an existing output if found, otherwise
@@ -119,7 +112,7 @@ output_format : str
         # Validate dataset-specific parameters
         self.validate_params(output_format=output_format, **dataset_kwargs)
 
-        # define output_path ad check if (file-based) output exists already
+        # define output_path and check if (file-based) output exists already
         output_path = self._output_path(output_format, cache_dir, export_dir, **dataset_kwargs)
         if output_path is not None and output_path.exists():
             return output_path
@@ -136,7 +129,6 @@ output_format : str
 
         # Convert to requested output format
         return self._to_output(sofa, output_format, output_path)
-
 
     def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
         """Return the canonical Path where a file-based output would be written.
@@ -160,8 +152,8 @@ output_format : str
         Path or None
             Canonical output path, or None for in-memory formats.
         """
-        return NotImplementedError(f"{self.__class__.__name__} must implement output_path)")
-  
+        raise NotImplementedError(f"{self.__class__.__name__} must implement output_path)")
+
     def validate_params(self, **dataset_kwargs) -> None:
         """Validate dataset-specific parameters.
 
@@ -221,7 +213,6 @@ output_format : str
         """
         raise NotImplementedError(f"{self.__class__.__name__} must implement ingest()")
 
-
     def _to_output(self, sofa: sf.Sofa, output_format: str, output_path: Path) -> Any:
         """Dispatch a sofar.Sofa object to the requested output format.
 
@@ -266,10 +257,15 @@ output_format : str
             - 'source_coordinates' : pyfar.Coordinates
             - 'receiver_coordinates' : pyfar.Coordinates
         """
+        receiver = np.asarray(sofa.ReceiverPosition).squeeze()  # (R, C, I) -> (R, 3)
+        source = np.asarray(sofa.SourcePosition)  # (M, C)
+        ir = np.asarray(sofa.Data_IR).squeeze()
+        sr = float(np.asarray(sofa.Data_SamplingRate).flat[0])
+
         return {
-            "impulse_response": pf.Signal(sofa.Data_IR, sampling_rate=sofa.Data_SamplingRate),
-            "source_coordinates": pf.Coordinates(*sofa.SourcePosition.T),
-            "receiver_coordinates": pf.Coordinates(*sofa.ReceiverPosition.T),
+            "impulse_response": pf.Signal(ir, sampling_rate=sr),
+            "source_coordinates": pf.Coordinates(source[:, 0], source[:, 1], source[:, 2]),
+            "receiver_coordinates": pf.Coordinates(receiver[:, 0], receiver[:, 1], receiver[:, 2]),
         }
 
     def _to_numpy(self, sofa: sf.Sofa) -> dict:
@@ -293,7 +289,7 @@ output_format : str
             "impulse_response": np.array(sofa.Data_IR),
             "source_coordinates": np.array(sofa.SourcePosition),
             "receiver_coordinates": np.array(sofa.ReceiverPosition),
-            "sampling_rate": float(sofa.Data_SamplingRate),
+            "sampling_rate": float(np.asarray(sofa.Data_SamplingRate).flat[0]),
         }
 
     def _to_sofa(self, sofa: sf.Sofa, output_path: Path) -> Path:
@@ -314,7 +310,6 @@ output_format : str
         output_path.parent.mkdir(parents=True, exist_ok=True)
         sf.write_sofa(str(output_path), sofa)
         return output_path
-    
 
     def _to_hdf5(self, sofa: sf.Sofa, output_path: Path) -> Path:
         """Write a sofar.Sofa object as an HDF5 file.
@@ -332,7 +327,7 @@ output_format : str
             Path to the written .h5 file.
         """
         output_path.parent.mkdir(parents=True, exist_ok=True)
-    
+
         with h5.File(output_path, "w") as f:
             data_group = f.create_group("data")
             data_group.create_dataset("impulse_response", data=sofa.Data_IR)
@@ -343,11 +338,9 @@ output_format : str
             meta_group.create_dataset("sampling_rate", data=sofa.Data_SamplingRate)
 
             # Add other metadata if present
-            if hasattr(sofa, "Data_Temperature"):
-                meta_group.create_dataset("temperature", data=sofa.Data_Temperature)
-            if hasattr(sofa, "Data_Humidity"):
-                meta_group.create_dataset("humidity", data=sofa.Data_Humidity)
-        
+            if hasattr(sofa, "RoomTemperature"):
+                meta_group.create_dataset("temperature", data=sofa.RoomTemperature)
+
         return output_path
 
     def _lookup(

--- a/src/irdl/base.py
+++ b/src/irdl/base.py
@@ -16,10 +16,10 @@ The BaseDataset class handles:
 - Output format conversion from SOFA
 """
 
+import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
-import warnings
 
 import numpy as np
 import pyfar as pf
@@ -98,9 +98,9 @@ output_format : str
 
         Parameters
         ----------
-        cache_dir : Path or str
+        cache_dir : :class:`pathlib.Path` or str
             Cache directory for downloads.
-        export_dir : Path or str or None
+        export_dir : :class:`pathlib.Path` or str or None
             Directory for final output. Default is None (stays in cache_dir).
         output_format : str
             Output format: 'pyfar', 'numpy', 'hdf5', 'sofa', or 'raw'.
@@ -109,9 +109,9 @@ output_format : str
 
         Returns
         -------
-        dict or Path
+        dict or :class:`pathlib.Path`
             For 'pyfar' / 'numpy': a dict of in-memory objects.
-            For 'sofa' / 'hdf5' / 'raw': a Path to the file on disk.
+            For 'sofa' / 'hdf5' / 'raw': a :class:`pathlib.Path` to the file on disk.
         """
         cache_dir = Path(cache_dir)
         export_dir = Path(export_dir) if export_dir else None
@@ -177,7 +177,7 @@ output_format : str
 
         Parameters
         ----------
-        target_path : Path
+        target_path : :class:`pathlib.Path`
             Target path where the file should be downloaded.
         **kwargs : dict
             Dataset-specific parameters (scenario, kind, hato, etc.).
@@ -185,7 +185,7 @@ output_format : str
 
         Returns
         -------
-        file_path : Path
+        file_path : :class:`pathlib.Path`
             Path to the downloaded/processed file on disk.
         """
         raise NotImplementedError(f"{self.__class__.__name__} must implement download()")
@@ -198,12 +198,12 @@ output_format : str
 
         Parameters
         ----------
-        file_path : Path
+        file_path : :class:`pathlib.Path`
             Path to the file returned by _get_file().
 
         Returns
         -------
-        sofa : sofar.Sofa
+        sofa : :class:`sofar.Sofa`
             SOFA object representing the Dataset data.
         """
         raise NotImplementedError(f"{self.__class__.__name__} must implement ingest()")
@@ -338,21 +338,21 @@ output_format : str
 
         Parameters
         ----------
-        sofa : sofar.Sofa
+        sofa : :class:`sofar.Sofa`
             SOFA object to convert.
         output_format : str
             One of "pyfar", "numpy", "hdf5", "sofa".
-        output_path : Path or None
+        output_path : :class:`pathlib.Path` or None
             Path where file-based outputs should be written.
 
         Returns
         -------
-        dict or Path
+        dict or :class:`pathlib.Path`
             Output depends on output_format:
-            - "pyfar" : dict of pyfar objects
-            - "numpy" : dict of numpy arrays
-            - "hdf5" : Path to .h5 file
-            - "sofa" : Path to .sofa file
+            - "pyfar" : dict of :class:`pyfar.Signal` and :class:`pyfar.Coordinates` objects
+            - "numpy" : dict of :class:`numpy.ndarray` arrays
+            - "hdf5" : :class:`pathlib.Path` to .h5 file
+            - "sofa" : :class:`pathlib.Path` to .sofa file
         """
         if output_format == "pyfar":
             return self._to_pyfar(sofa)
@@ -370,22 +370,22 @@ output_format : str
 
         Parameters
         ----------
-        sofa : sofar.Sofa
+        sofa : :class:`sofar.Sofa`
             SOFA object to convert.
 
         Returns
         -------
         dict
             Dictionary with keys:
-            - "impulse_response" : pyfar.Signal
-            - "source_coordinates" : pyfar.Coordinates
-            - "receiver_coordinates" : pyfar.Coordinates
+            - "impulse_response" : :class:`pyfar.Signal`
+            - "source_coordinates" : :class:`pyfar.Coordinates`
+            - "receiver_coordinates" : :class:`pyfar.Coordinates`
         """
         # Squeeze to remove singleton dimensions before transposing
         # This handles both 2D (N, 3) and 3D (N, 3, 1) coordinate arrays
         source_pos = np.squeeze(sofa.SourcePosition)
         receiver_pos = np.squeeze(sofa.ReceiverPosition)
-        
+
         # Extract scalar sampling rate (SOFA Data_SamplingRate can be scalar or array)
         sampling_rate = sofa.Data_SamplingRate
         if np.ndim(sampling_rate) > 0:
@@ -393,16 +393,16 @@ output_format : str
             flat_sr = sampling_rate.flatten()
             unique_sr = np.unique(flat_sr)
             sampling_rate = unique_sr[0]
-            
+
             # Warn if there are multiple different sampling rates
             if len(unique_sr) > 1:
                 warnings.warn(
                     f"Multiple sampling rates found in SOFA file: {unique_sr}. "
                     f"Using {sampling_rate} Hz for pyfar Signal.",
                     UserWarning,
-                    stacklevel=2
+                    stacklevel=2,
                 )
-        
+
         return {
             "impulse_response": pf.Signal(sofa.Data_IR, sampling_rate=sampling_rate),
             "source_coordinates": pf.Coordinates(*source_pos.T),
@@ -414,16 +414,16 @@ output_format : str
 
         Parameters
         ----------
-        sofa : sofar.Sofa
+        sofa : :class:`sofar.Sofa`
             SOFA object to convert.
 
         Returns
         -------
         dict
             Dictionary with keys:
-            - "impulse_response" : numpy.ndarray
-            - "source_coordinates" : numpy.ndarray
-            - "receiver_coordinates" : numpy.ndarray
+            - "impulse_response" : :class:`numpy.ndarray`
+            - "source_coordinates" : :class:`numpy.ndarray`
+            - "receiver_coordinates" : :class:`numpy.ndarray`
             - "sampling_rate" : float
         """
         return {
@@ -438,14 +438,14 @@ output_format : str
 
         Parameters
         ----------
-        sofa : sofar.Sofa
+        sofa : :class:`sofar.Sofa`
             SOFA object to write.
-        output_path : Path
+        output_path : :class:`pathlib.Path`
             Path where the .sofa file should be written.
 
         Returns
         -------
-        Path
+        :class:`pathlib.Path`
             Path to the written SOFA file.
         """
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -457,14 +457,14 @@ output_format : str
 
         Parameters
         ----------
-        sofa : sofar.Sofa
+        sofa : :class:`sofar.Sofa`
             SOFA object to convert.
-        output_path : Path
+        output_path : :class:`pathlib.Path`
             Path where the .h5 file should be written.
 
         Returns
         -------
-        Path
+        :class:`pathlib.Path`
             Path to the written HDF5 file.
         """
         import h5py as h5

--- a/src/irdl/base.py
+++ b/src/irdl/base.py
@@ -117,7 +117,7 @@ output_format : str
             raise ValueError("output_format must be one of 'pyfar', 'hdf5', 'numpy', 'sofa', 'raw'")
 
         # Validate dataset-specific parameters
-        self.validate_params(**dataset_kwargs)
+        self.validate_params(output_format=output_format, **dataset_kwargs)
 
         # define output_path ad check if (file-based) output exists already
         output_path = self._output_path(output_format, cache_dir, export_dir, **dataset_kwargs)
@@ -162,16 +162,17 @@ output_format : str
         """
         return NotImplementedError(f"{self.__class__.__name__} must implement output_path)")
   
-    def validate_params(self, **dataset_kwargs: dict) -> None:
+    def validate_params(self, **dataset_kwargs) -> None:
         """Validate dataset-specific parameters.
 
-        Override in subclass. Common parameters (cache_dir, export_dir,
-        output_format) are validated in _get.
+        Override in subclass. Receives the dataset-specific parameters plus
+        ``output_format`` (so subclasses can forbid invalid output_format /
+        dataset-parameter combinations).
 
         Parameters
         ----------
         **dataset_kwargs
-            Dataset-specific parameters to validate.
+            Dataset-specific parameters to validate, plus ``output_format``.
 
         Raises
         ------

--- a/src/irdl/base.py
+++ b/src/irdl/base.py
@@ -30,19 +30,24 @@ class BaseDataset(ABC):
 
     Subclasses must implement the following abstract methods:
 
-    - name : :class:`str`
+    Attributes
+    ----------
+    name : str
         Unique identifier for the Dataset.
-    - doi : :class:`str`
+    doi : str
         Digital Object Identifier for the Dataset.
-    - validate_params(**dataset_kwargs)
+
+    Methods
+    -------
+    validate_params(**dataset_kwargs)
         Validate dataset-specific parameters (including output_format).
-    - download(**kwargs) -> Path
-        Download and return :class:`pathlib.Path` to raw file.
-    - ingest(file_path: Path) -> sofar.Sofa
-        Convert raw file to :class:`sofar.Sofa` object.
-    - _source_filename(**kwargs) -> str
+    download(**kwargs) -> Path
+        Download and return Path to raw file.
+    ingest(file_path: Path) -> sofar.Sofa
+        Convert raw file to sofar.Sofa object.
+    _source_filename(**kwargs) -> str
         Construct the raw input filename with extension.
-    - get() @classmethod
+    get() @classmethod
         Public entry point with explicit type signature for CLI auto-generation.
     """
 
@@ -78,23 +83,27 @@ output_format : str
             # Combine: prefix + suffix
             full_doc = prefix
             if suffix:
-                if not full_doc.endswith("\n\n"):
-                    full_doc += "\n\n"
                 full_doc += suffix
             get_func.__doc__ = full_doc
 
-    def _get(self, *, cache_dir: str, export_dir: str | None, output_format: str, **dataset_kwargs) -> Any:
+    def _get(
+        self,
+        cache_dir: Path | str,
+        export_dir: Path | str | None,
+        output_format: str,
+        **dataset_kwargs,
+    ) -> Any:
         """Internal implementation of Dataset retrieval.
 
         Parameters
         ----------
-        cache_dir : str
+        cache_dir : Path or str
             Cache directory for downloads.
-        export_dir : str, optional
-            Directory for final output.
+        export_dir : Path or str or None
+            Directory for final output. Default is None (stays in cache_dir).
         output_format : str
             Output format: 'pyfar', 'numpy', 'hdf5', 'sofa', or 'raw'.
-        **dataset_kwargs
+        **dataset_kwargs : dict
             Dataset-specific parameters.
 
         Returns
@@ -113,20 +122,25 @@ output_format : str
         # Validate dataset-specific parameters (including output_format)
         self.validate_params(output_format=output_format, **dataset_kwargs)
 
-        # Early return if output file already exists
+        # Early exit if output file already exists
         output_path = self._output_path(output_format, cache_dir, export_dir, **dataset_kwargs)
         if output_path is not None and output_path.exists():
             return output_path
 
-        # Get the raw file (download if needed)
-        file_path = self._get_file(cache_dir=cache_dir, export_dir=export_dir, **dataset_kwargs)
+        # path to cache file
+        file_path = self._input_path(cache_dir, None, **dataset_kwargs)
+        if not file_path.exists():
+            self.download(file_path, **dataset_kwargs)
 
-        # For raw output, return the file directly without processing
+        # return raw file if requested
         if output_format == "raw":
-            return file_path
-
-        # Process the file if needed (e.g., extraction, merging)
-        processed_path = self._process(file_path, **dataset_kwargs)
+            if export_dir is None:
+                return file_path
+            else:
+                return self._move_to_export(file_path, export_dir)
+        else:
+            # Process the file if needed (e.g., extraction, merging)
+            processed_path = self._process(file_path, **dataset_kwargs)
 
         # Ingest to SOFA (internal standard)
         sofa = self.ingest(processed_path)
@@ -144,7 +158,7 @@ output_format : str
 
         Parameters
         ----------
-        **dataset_kwargs
+        **dataset_kwargs : dict
             Dataset-specific parameters to validate, including ``output_format``.
 
         Raises
@@ -155,38 +169,40 @@ output_format : str
         raise NotImplementedError(f"{self.__class__.__name__} must implement validate_params()")
 
     @abstractmethod
-    def download(self, **kwargs) -> Path:
-        """Download raw files and return :class:`pathlib.Path` to the primary file.
+    def download(self, target_path: Path, **kwargs) -> Path:
+        """Download raw files and return Path to the primary file.
 
         Override in subclass.
 
         Parameters
         ----------
-        **kwargs : :class:`dict`
+        target_path : Path
+            Target path where the file should be downloaded.
+        **kwargs : dict
             Dataset-specific parameters (scenario, kind, hato, etc.).
-            cache_dir and export_dir are NOT in kwargs (handled by _get_file()).
+            cache_dir and export_dir are NOT in kwargs (handled by _get()).
 
         Returns
         -------
-        file_path : :class:`pathlib.Path`
+        file_path : Path
             Path to the downloaded/processed file on disk.
         """
         raise NotImplementedError(f"{self.__class__.__name__} must implement download()")
 
     @abstractmethod
     def ingest(self, file_path: Path) -> sf.Sofa:
-        """Convert raw file to :class:`sofar.Sofa` object.
+        """Convert raw file to sofar.Sofa object.
 
         Override in subclass.
 
         Parameters
         ----------
-        file_path : :class:`pathlib.Path`
+        file_path : Path
             Path to the file returned by _get_file().
 
         Returns
         -------
-        sofa : :class:`sofar.Sofa`
+        sofa : sofar.Sofa
             SOFA object representing the Dataset data.
         """
         raise NotImplementedError(f"{self.__class__.__name__} must implement ingest()")
@@ -199,13 +215,14 @@ output_format : str
 
         Parameters
         ----------
-        **kwargs : :class:`dict`
+        **kwargs : dict
             Dataset-specific parameters used to construct the filename.
 
         Returns
         -------
-        :class:`str`
-            The raw input filename including extension (e.g., "A1.h5", "FABIAN_HRIR_measured_HATO_0.sofa").
+        str
+            The raw input filename including extension (e.g., "A1.h5",
+            "FABIAN_HRIR_measured_HATO_0.sofa").
         """
         raise NotImplementedError(f"{self.__class__.__name__} must implement _source_filename()")
 
@@ -214,21 +231,20 @@ output_format : str
 
         Parameters
         ----------
-        cache_dir : :class:`pathlib.Path`
+        cache_dir : Path
             Cache directory.
-        export_dir : :class:`pathlib.Path` or :class:`None`
+        export_dir : Path or None
             Optional export directory; takes priority over cache_dir.
-        **kwargs : :class:`dict`
+        **kwargs : dict
             Dataset-specific parameters passed to _source_filename().
 
         Returns
         -------
-        :class:`pathlib.Path`
+        Path
             Full path to the raw input file under '<base>/<DATASET_NAME>/'.
         """
-        filename = self._source_filename(**kwargs)
         base = (export_dir if export_dir is not None else cache_dir) / self.name.upper()
-        return base / filename
+        return base / self._source_filename(**kwargs)
 
     def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
         """Return the canonical Path where a file-based output would be written.
@@ -244,7 +260,7 @@ output_format : str
             Cache directory.
         export_dir : Path or None
             Optional export directory; takes priority over cache_dir.
-        **kwargs
+        **kwargs : dict
             Dataset-specific parameters used to construct the filename.
 
         Returns
@@ -253,62 +269,21 @@ output_format : str
             Canonical output path under '<base>/<DATASET_NAME>/', or None for
             in-memory formats.
         """
-        if output_format in ("pyfar", "numpy"):
-            return None
-
-        source_filename = self._source_filename(**kwargs)
-        stem = Path(source_filename).stem
+        source_filename = Path(self._source_filename(**kwargs))
 
         # Determine extension based on output format
-        if output_format == "sofa":
-            ext = ".sofa"
-        elif output_format == "hdf5":
-            ext = ".h5"
-        elif output_format == "raw":
-            # Keep original extension for raw output
-            ext = Path(source_filename).suffix
-        else:
-            return None
+        match output_format:
+            case "numpy" | "pyfar":
+                return None
+            case "sofa":
+                suff = ".sofa"
+            case "hdf5":
+                suff = ".h5"
+            case "raw":
+                suff = source_filename.suffix
 
         base = (export_dir if export_dir is not None else cache_dir) / self.name.upper()
-        return base / f"{stem}{ext}"
-
-    def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
-        """Check cache or download file.
-
-        Parameters
-        ----------
-        cache_dir : :class:`pathlib.Path`
-            Base cache directory.
-        export_dir : :class:`pathlib.Path` or :class:`None`
-            Optional export directory.
-        **kwargs : :class:`dict`
-            Dataset-specific parameters passed to download().
-
-        Returns
-        -------
-        file_path : :class:`pathlib.Path`
-            Path to the file on disk (either cached or newly downloaded).
-        """
-        # Get the full input path (subclass must implement _source_filename)
-        file_path = self._input_path(cache_dir, export_dir, **kwargs)
-        file_cache = file_path
-        file_export = file_path if export_dir is not None else None
-
-        # Check if file exists in export_dir or cache_dir
-        if file_export is not None and file_export.exists():
-            return file_export
-        if file_cache.exists():
-            return file_cache
-
-        # File not cached - download it
-        downloaded_path = self.download(**kwargs)
-
-        # Move to export_dir if specified and different from cache_dir
-        if export_dir is not None and export_dir != cache_dir:
-            return self._move_to_export(downloaded_path, export_dir)
-
-        return downloaded_path
+        return (base / source_filename.stem).with_suffix(suff)
 
     def _process(self, file_path: Path, **kwargs) -> Path:
         """Post-process downloaded file if needed.
@@ -318,61 +293,31 @@ output_format : str
 
         Parameters
         ----------
-        file_path : :class:`pathlib.Path`
+        file_path : Path
             Path to the raw downloaded file.
-        **kwargs : :class:`dict`
+        **kwargs : dict
             Dataset-specific parameters (may be needed for processing decisions).
 
         Returns
         -------
-        file_path : :class:`pathlib.Path`
+        file_path : Path
             Path to the processed file (may be same as input if no processing needed).
         """
         return file_path
-
-
-
-    def _lookup(self, file_name: str, cache_dir: Path, export_dir: Path | None) -> Path | None:
-        """Return the path if the file exists in export_dir or cache_dir, else None.
-
-        Searches export_dir first, falling back to cache_dir.
-
-        Parameters
-        ----------
-        file_name : str
-            File name to search for.
-        cache_dir : Path
-            Cache directory to search.
-        export_dir : Path or None
-            Optional export directory to search first.
-
-        Returns
-        -------
-        Path or None
-            Path to the existing file, or None if not found.
-        """
-        if export_dir is not None:
-            p = export_dir / file_name
-            if p.exists():
-                return p
-        p = cache_dir / file_name
-        if p.exists():
-            return p
-        return None
 
     def _move_to_export(self, source: Path, export_dir: Path) -> Path:
         """Move file from source to export_dir.
 
         Parameters
         ----------
-        source : :class:`pathlib.Path`
+        source : Path
             Source file path.
-        export_dir : :class:`pathlib.Path`
+        export_dir : Path
             Target export directory.
 
         Returns
         -------
-        :class:`pathlib.Path`
+        Path
             Path to the file in export_dir.
         """
         import shutil
@@ -388,25 +333,25 @@ output_format : str
         return target
 
     def _to_output(self, sofa: sf.Sofa, output_format: str, output_path: Path | None) -> Any:
-        """Convert :class:`sofar.Sofa` to the requested output format.
+        """Convert sofar.Sofa to the requested output format.
 
         Parameters
         ----------
-        sofa : :class:`sofar.Sofa`
+        sofa : sofar.Sofa
             SOFA object to convert.
-        output_format : :class:`str`
+        output_format : str
             One of "pyfar", "numpy", "hdf5", "sofa".
-        output_path : :class:`pathlib.Path` or :class:`None`
+        output_path : Path or None
             Path where file-based outputs should be written.
 
         Returns
         -------
-        :class:`Any`
+        dict or Path
             Output depends on output_format:
-            - "pyfar" : :class:`dict` of pyfar objects
-            - "numpy" : :class:`dict` of numpy arrays
-            - "hdf5" : :class:`pathlib.Path` to .h5 file
-            - "sofa" : :class:`pathlib.Path` to .sofa file
+            - "pyfar" : dict of pyfar objects
+            - "numpy" : dict of numpy arrays
+            - "hdf5" : Path to .h5 file
+            - "sofa" : Path to .sofa file
         """
         if output_format == "pyfar":
             return self._to_pyfar(sofa)
@@ -420,20 +365,20 @@ output_format : str
             raise ValueError(f"Unknown output_format: {output_format}")
 
     def _to_pyfar(self, sofa: sf.Sofa) -> dict:
-        """Convert :class:`sofar.Sofa` to :class:`dict` of pyfar objects.
+        """Convert sofar.Sofa to dict of pyfar objects.
 
         Parameters
         ----------
-        sofa : :class:`sofar.Sofa`
+        sofa : sofar.Sofa
             SOFA object to convert.
 
         Returns
         -------
-        :class:`dict`
+        dict
             Dictionary with keys:
-            - "impulse_response" : :class:`pyfar.Signal`
-            - "source_coordinates" : :class:`pyfar.Coordinates`
-            - "receiver_coordinates" : :class:`pyfar.Coordinates`
+            - "impulse_response" : pyfar.Signal
+            - "source_coordinates" : pyfar.Coordinates
+            - "receiver_coordinates" : pyfar.Coordinates
         """
         return {
             "impulse_response": pf.Signal(sofa.Data_IR, sampling_rate=sofa.Data_SamplingRate),
@@ -442,21 +387,21 @@ output_format : str
         }
 
     def _to_numpy(self, sofa: sf.Sofa) -> dict:
-        """Convert :class:`sofar.Sofa` to :class:`dict` of numpy arrays.
+        """Convert sofar.Sofa to dict of numpy arrays.
 
         Parameters
         ----------
-        sofa : :class:`sofar.Sofa`
+        sofa : sofar.Sofa
             SOFA object to convert.
 
         Returns
         -------
-        :class:`dict`
+        dict
             Dictionary with keys:
-            - "impulse_response" : :class:`numpy.ndarray`
-            - "source_coordinates" : :class:`numpy.ndarray`
-            - "receiver_coordinates" : :class:`numpy.ndarray`
-            - "sampling_rate" : :class:`float`
+            - "impulse_response" : numpy.ndarray
+            - "source_coordinates" : numpy.ndarray
+            - "receiver_coordinates" : numpy.ndarray
+            - "sampling_rate" : float
         """
         return {
             "impulse_response": np.array(sofa.Data_IR),
@@ -466,18 +411,18 @@ output_format : str
         }
 
     def _to_sofa(self, sofa: sf.Sofa, output_path: Path) -> Path:
-        """Write :class:`sofar.Sofa` to file and return :class:`pathlib.Path`.
+        """Write sofar.Sofa to file and return Path.
 
         Parameters
         ----------
-        sofa : :class:`sofar.Sofa`
+        sofa : sofar.Sofa
             SOFA object to write.
-        output_path : :class:`pathlib.Path`
+        output_path : Path
             Path where the .sofa file should be written.
 
         Returns
         -------
-        :class:`pathlib.Path`
+        Path
             Path to the written SOFA file.
         """
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -485,18 +430,18 @@ output_format : str
         return output_path
 
     def _to_hdf5(self, sofa: sf.Sofa, output_path: Path) -> Path:
-        """Convert :class:`sofar.Sofa` to HDF5 file and return :class:`pathlib.Path`.
+        """Convert sofar.Sofa to HDF5 file and return Path.
 
         Parameters
         ----------
-        sofa : :class:`sofar.Sofa`
+        sofa : sofar.Sofa
             SOFA object to convert.
-        output_path : :class:`pathlib.Path`
+        output_path : Path
             Path where the .h5 file should be written.
 
         Returns
         -------
-        :class:`pathlib.Path`
+        Path
             Path to the written HDF5 file.
         """
         import h5py as h5
@@ -520,6 +465,8 @@ output_format : str
             # Add other metadata if present
             if hasattr(sofa, "RoomTemperature"):
                 meta_group.create_dataset("temperature", data=sofa.RoomTemperature)
+            elif hasattr(sofa, "Data_Temperature"):
+                meta_group.create_dataset("temperature", data=sofa.Data_Temperature)
             if hasattr(sofa, "Data_Humidity"):
                 meta_group.create_dataset("humidity", data=sofa.Data_Humidity)
 

--- a/src/irdl/base.py
+++ b/src/irdl/base.py
@@ -19,6 +19,7 @@ The BaseDataset class handles:
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
+import warnings
 
 import numpy as np
 import pyfar as pf
@@ -380,10 +381,32 @@ output_format : str
             - "source_coordinates" : pyfar.Coordinates
             - "receiver_coordinates" : pyfar.Coordinates
         """
+        # Squeeze to remove singleton dimensions before transposing
+        # This handles both 2D (N, 3) and 3D (N, 3, 1) coordinate arrays
+        source_pos = np.squeeze(sofa.SourcePosition)
+        receiver_pos = np.squeeze(sofa.ReceiverPosition)
+        
+        # Extract scalar sampling rate (SOFA Data_SamplingRate can be scalar or array)
+        sampling_rate = sofa.Data_SamplingRate
+        if np.ndim(sampling_rate) > 0:
+            # Flatten and get unique values
+            flat_sr = sampling_rate.flatten()
+            unique_sr = np.unique(flat_sr)
+            sampling_rate = unique_sr[0]
+            
+            # Warn if there are multiple different sampling rates
+            if len(unique_sr) > 1:
+                warnings.warn(
+                    f"Multiple sampling rates found in SOFA file: {unique_sr}. "
+                    f"Using {sampling_rate} Hz for pyfar Signal.",
+                    UserWarning,
+                    stacklevel=2
+                )
+        
         return {
-            "impulse_response": pf.Signal(sofa.Data_IR, sampling_rate=sofa.Data_SamplingRate),
-            "source_coordinates": pf.Coordinates(*sofa.SourcePosition.T),
-            "receiver_coordinates": pf.Coordinates(*sofa.ReceiverPosition.T),
+            "impulse_response": pf.Signal(sofa.Data_IR, sampling_rate=sampling_rate),
+            "source_coordinates": pf.Coordinates(*source_pos.T),
+            "receiver_coordinates": pf.Coordinates(*receiver_pos.T),
         }
 
     def _to_numpy(self, sofa: sf.Sofa) -> dict:

--- a/src/irdl/base.py
+++ b/src/irdl/base.py
@@ -1,47 +1,56 @@
 """Base Dataset class and conversion utilities for IRDL.
 
-Provides the BaseDataset class that defines the common interface and pipeline
-shared by all dataset implementations. Subclasses implement dataset-specific
-logic for parameter validation, file retrieval, ingestion, and output naming.
+This module provides the BaseDataset abstract base class which serves as the common interface
+for all Dataset implementations. Each Dataset subclass must implement:
+
+- validate_params()
+- download()
+- ingest()
+- _construct_file_name()
+- _output_path()
+
+The BaseDataset class handles:
+
+- Common parameter extraction
+- Path construction
+- Cache checking
+- Output format conversion from SOFA
 """
 
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
-import h5py as h5
 import numpy as np
 import pyfar as pf
 import sofar as sf
 
 
-class BaseDataset:
-    """Common interface and pipeline for all dataset implementations.
+class BaseDataset(ABC):
+    """Abstract base class providing common interface for all Dataset implementations.
 
-    Subclasses must define:
+    Subclasses must implement the following abstract methods:
 
-    - name : str
-        Unique identifier for the dataset.
-    - doi : str
-        Digital Object Identifier for the dataset.
-    - raw_format : str
-        Native file format of the publisher's raw files (e.g. 'hdf5' for ISTA,
-        'sofa' for FABIAN). Used to short-circuit the pipeline when the
-        requested output format matches the raw format.
+    - name : :class:`str`
+        Unique identifier for the Dataset.
+    - doi : :class:`str`
+        Digital Object Identifier for the Dataset.
     - validate_params(**dataset_kwargs)
-        Validate dataset-specific parameters.
-    - _get_file(cache_dir, export_dir, **kwargs) -> Path
-        Fetch and process the raw file; return the path ready for ingest().
-    - ingest(file_path) -> sofar.Sofa
-        Convert the raw file into a SOFA object.
+        Validate dataset-specific parameters (including output_format).
+    - download(**kwargs) -> Path
+        Download and return :class:`pathlib.Path` to raw file.
+    - ingest(file_path: Path) -> sofar.Sofa
+        Convert raw file to :class:`sofar.Sofa` object.
+    - _construct_file_name(**kwargs) -> str
+        Construct the file name for raw input files.
     - _output_path(output_format, cache_dir, export_dir, **kwargs) -> Path or None
-        Canonical path where output is written; None for in-memory formats.
+        Canonical path for output files; None for in-memory formats.
     - get() @classmethod
-        Public entry point with an explicit signature for CLI auto-generation.
+        Public entry point with explicit type signature for CLI auto-generation.
     """
 
     name: str
     doi: str
-    raw_format: str
 
     # Default docstring prefix for all get() classmethods
     _get_doc_prefix = """Download {name} dataset.
@@ -59,7 +68,7 @@ output_format : str
 """
 
     def __init_subclass__(cls, **kwargs):
-        """Compose the get() docstring when a subclass is defined."""
+        """Initialize subclass with automatic docstring composition for get() classmethod."""
         super().__init_subclass__(**kwargs)
         # Automatically compose docstrings for get() classmethod
         if hasattr(cls, "get") and hasattr(cls, "name") and hasattr(cls, "doi"):
@@ -78,21 +87,16 @@ output_format : str
             get_func.__doc__ = full_doc
 
     def _get(self, *, cache_dir: str, export_dir: str | None, output_format: str, **dataset_kwargs) -> Any:
-        """Execute the full dataset retrieval pipeline.
-
-        Validates parameters, returns an existing output if found, otherwise
-        fetches and processes the raw file, ingests it to SOFA, and converts
-        to the requested output format.
+        """Internal implementation of Dataset retrieval.
 
         Parameters
         ----------
         cache_dir : str
-            Cache directory for downloads and intermediate files.
-        export_dir : str or None
-            Optional directory for final output. If None, files stay in
-            cache_dir.
+            Cache directory for downloads.
+        export_dir : str, optional
+            Directory for final output.
         output_format : str
-            One of 'pyfar', 'numpy', 'hdf5', 'sofa', 'raw'.
+            Output format: 'pyfar', 'numpy', 'hdf5', 'sofa', or 'raw'.
         **dataset_kwargs
             Dataset-specific parameters.
 
@@ -109,27 +113,88 @@ output_format : str
         if output_format not in ("pyfar", "hdf5", "numpy", "sofa", "raw"):
             raise ValueError("output_format must be one of 'pyfar', 'hdf5', 'numpy', 'sofa', 'raw'")
 
-        # Validate dataset-specific parameters
+        # Validate dataset-specific parameters (including output_format)
         self.validate_params(output_format=output_format, **dataset_kwargs)
 
-        # define output_path and check if (file-based) output exists already
+        # Early return if output file already exists
         output_path = self._output_path(output_format, cache_dir, export_dir, **dataset_kwargs)
         if output_path is not None and output_path.exists():
             return output_path
 
         # Get the raw file (download if needed)
-        file_path = self._get_file(cache_dir, export_dir, **dataset_kwargs)
+        file_path = self._get_file(cache_dir=cache_dir, export_dir=export_dir, **dataset_kwargs)
 
         # For raw output, return the file directly without processing
-        if output_format == "raw" or output_format == self.raw_format:
+        if output_format == "raw":
             return file_path
 
+        # Process the file if needed (e.g., extraction, merging)
+        processed_path = self._process(file_path, **dataset_kwargs)
+
         # Ingest to SOFA (internal standard)
-        sofa = self.ingest(file_path)
+        sofa = self.ingest(processed_path)
 
         # Convert to requested output format
         return self._to_output(sofa, output_format, output_path)
 
+    @abstractmethod
+    def validate_params(self, **dataset_kwargs) -> None:
+        """Validate dataset-specific parameters.
+
+        Override in subclass. This method receives dataset-specific parameters
+        plus ``output_format`` (so subclasses can forbid invalid output_format /
+        dataset-parameter combinations).
+
+        Parameters
+        ----------
+        **dataset_kwargs
+            Dataset-specific parameters to validate, including ``output_format``.
+
+        Raises
+        ------
+        ValueError
+            If any parameter is invalid.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} must implement validate_params()")
+
+    @abstractmethod
+    def download(self, **kwargs) -> Path:
+        """Download raw files and return :class:`pathlib.Path` to the primary file.
+
+        Override in subclass.
+
+        Parameters
+        ----------
+        **kwargs : :class:`dict`
+            Dataset-specific parameters (scenario, kind, hato, etc.).
+            cache_dir and export_dir are NOT in kwargs (handled by _get_file()).
+
+        Returns
+        -------
+        file_path : :class:`pathlib.Path`
+            Path to the downloaded/processed file on disk.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} must implement download()")
+
+    @abstractmethod
+    def ingest(self, file_path: Path) -> sf.Sofa:
+        """Convert raw file to :class:`sofar.Sofa` object.
+
+        Override in subclass.
+
+        Parameters
+        ----------
+        file_path : :class:`pathlib.Path`
+            Path to the file returned by _get_file().
+
+        Returns
+        -------
+        sofa : :class:`sofar.Sofa`
+            SOFA object representing the Dataset data.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} must implement ingest()")
+
+    @abstractmethod
     def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
         """Return the canonical Path where a file-based output would be written.
 
@@ -152,203 +217,84 @@ output_format : str
         Path or None
             Canonical output path, or None for in-memory formats.
         """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement output_path)")
+        raise NotImplementedError(f"{self.__class__.__name__} must implement _output_path()")
 
-    def validate_params(self, **dataset_kwargs) -> None:
-        """Validate dataset-specific parameters.
-
-        Override in subclass. Receives the dataset-specific parameters plus
-        ``output_format`` (so subclasses can forbid invalid output_format /
-        dataset-parameter combinations).
+    def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
+        """Check cache or download file.
 
         Parameters
         ----------
-        **dataset_kwargs
-            Dataset-specific parameters to validate, plus ``output_format``.
-
-        Raises
-        ------
-        ValueError
-            If any parameter is invalid.
-        """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement validate_params()")
-
-    def _get_file(self, cache_dir, export_dir, **kwargs) -> Path:
-        """Return the path to a file ready for ingest().
-
-        Subclass implements the input-side flow: check cache, download what is
-        missing, perform any merging or splitting, return the final path.
-
-        Parameters
-        ----------
-        cache_dir : Path
-            Cache directory for downloads.
-        export_dir : Path or None
-            Optional directory for final output; takes priority over cache_dir
-            for writes.
-        **kwargs
-            Dataset-specific parameters.
+        cache_dir : :class:`pathlib.Path`
+            Base cache directory.
+        export_dir : :class:`pathlib.Path` or :class:`None`
+            Optional export directory.
+        **kwargs : :class:`dict`
+            Dataset-specific parameters passed to download().
 
         Returns
         -------
-        Path
-            Path to the file ready to be passed to ingest().
+        file_path : :class:`pathlib.Path`
+            Path to the file on disk (either cached or newly downloaded).
         """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement _get_file()")
+        # Construct expected file name based on Dataset (subclass must implement)
+        file_name = self._construct_file_name(**kwargs)
+        file_cache = cache_dir / file_name
+        file_export = Path(export_dir) / file_name if export_dir else None
 
-    def ingest(self, file_path: Path) -> sf.Sofa:
-        """Convert a raw file into a sofar.Sofa object.
+        # Check if file exists in export_dir or cache_dir
+        if file_export is not None and file_export.exists():
+            return file_export
+        if file_cache.exists():
+            return file_cache
+
+        # File not cached - download it
+        downloaded_path = self.download(**kwargs)
+
+        # Move to export_dir if specified and different from cache_dir
+        if export_dir is not None and export_dir != cache_dir:
+            return self._move_to_export(downloaded_path, export_dir)
+
+        return downloaded_path
+
+    def _process(self, file_path: Path, **kwargs) -> Path:
+        """Post-process downloaded file if needed.
+
+        Override in subclass to extract, transform, or otherwise process
+        the raw downloaded file before ingestion.
+
+        Parameters
+        ----------
+        file_path : :class:`pathlib.Path`
+            Path to the raw downloaded file.
+        **kwargs : :class:`dict`
+            Dataset-specific parameters (may be needed for processing decisions).
+
+        Returns
+        -------
+        file_path : :class:`pathlib.Path`
+            Path to the processed file (may be same as input if no processing needed).
+        """
+        return file_path
+
+    @abstractmethod
+    def _construct_file_name(self, **kwargs) -> str:
+        """Construct the file name for raw input files.
 
         Override in subclass.
 
         Parameters
         ----------
-        file_path : Path
-            Path to the file returned by _get_file().
+        **kwargs : :class:`dict`
+            Dataset-specific parameters used to construct the file name.
 
         Returns
         -------
-        sofar.Sofa
-            SOFA object representing the dataset.
+        :class:`str`
+            The constructed file name.
         """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement ingest()")
+        raise NotImplementedError(f"{self.__class__.__name__} must implement _construct_file_name()")
 
-    def _to_output(self, sofa: sf.Sofa, output_format: str, output_path: Path) -> Any:
-        """Dispatch a sofar.Sofa object to the requested output format.
-
-        Parameters
-        ----------
-        sofa : sofar.Sofa
-            SOFA object to convert.
-        output_format : str
-            One of 'pyfar', 'numpy', 'hdf5', 'sofa'.
-        output_path : Path
-            Where to write file-based outputs ('sofa', 'hdf5'). Ignored for
-            in-memory formats ('pyfar', 'numpy').
-
-        Returns
-        -------
-        dict or Path
-            'pyfar' / 'numpy': dict of in-memory objects.
-            'sofa' / 'hdf5': Path to the written file.
-        """
-        if output_format == "pyfar":
-            return self._to_pyfar(sofa)
-        if output_format == "numpy":
-            return self._to_numpy(sofa)
-        if output_format == "sofa":
-            return self._to_sofa(sofa, output_path)
-        if output_format == "hdf5":
-            return self._to_hdf5(sofa, output_path)
-
-    def _to_pyfar(self, sofa: sf.Sofa) -> dict:
-        """Convert a sofar.Sofa object into a dict of pyfar objects.
-
-        Parameters
-        ----------
-        sofa : sofar.Sofa
-            SOFA object to convert.
-
-        Returns
-        -------
-        dict
-            Keys:
-            - 'impulse_response' : pyfar.Signal
-            - 'source_coordinates' : pyfar.Coordinates
-            - 'receiver_coordinates' : pyfar.Coordinates
-        """
-        receiver = np.asarray(sofa.ReceiverPosition).squeeze()  # (R, C, I) -> (R, 3)
-        source = np.asarray(sofa.SourcePosition)  # (M, C)
-        ir = np.asarray(sofa.Data_IR).squeeze()
-        sr = float(np.asarray(sofa.Data_SamplingRate).flat[0])
-
-        return {
-            "impulse_response": pf.Signal(ir, sampling_rate=sr),
-            "source_coordinates": pf.Coordinates(source[:, 0], source[:, 1], source[:, 2]),
-            "receiver_coordinates": pf.Coordinates(receiver[:, 0], receiver[:, 1], receiver[:, 2]),
-        }
-
-    def _to_numpy(self, sofa: sf.Sofa) -> dict:
-        """Convert a sofar.Sofa object into a dict of numpy arrays.
-
-        Parameters
-        ----------
-        sofa : sofar.Sofa
-            SOFA object to convert.
-
-        Returns
-        -------
-        dict
-            Keys:
-            - 'impulse_response' : numpy.ndarray
-            - 'source_coordinates' : numpy.ndarray
-            - 'receiver_coordinates' : numpy.ndarray
-            - 'sampling_rate' : float
-        """
-        return {
-            "impulse_response": np.array(sofa.Data_IR),
-            "source_coordinates": np.array(sofa.SourcePosition),
-            "receiver_coordinates": np.array(sofa.ReceiverPosition),
-            "sampling_rate": float(np.asarray(sofa.Data_SamplingRate).flat[0]),
-        }
-
-    def _to_sofa(self, sofa: sf.Sofa, output_path: Path) -> Path:
-        """Write a sofar.Sofa object to a .sofa file.
-
-        Parameters
-        ----------
-        sofa : sofar.Sofa
-            SOFA object to write.
-        output_path : Path
-            Path where the .sofa file is written.
-
-        Returns
-        -------
-        Path
-            Path to the written .sofa file.
-        """
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        sf.write_sofa(str(output_path), sofa)
-        return output_path
-
-    def _to_hdf5(self, sofa: sf.Sofa, output_path: Path) -> Path:
-        """Write a sofar.Sofa object as an HDF5 file.
-
-        Parameters
-        ----------
-        sofa : sofar.Sofa
-            SOFA object to write.
-        output_path : Path
-            Path where the .h5 file is written.
-
-        Returns
-        -------
-        Path
-            Path to the written .h5 file.
-        """
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-        with h5.File(output_path, "w") as f:
-            data_group = f.create_group("data")
-            data_group.create_dataset("impulse_response", data=sofa.Data_IR)
-            loc_group = data_group.create_group("location")
-            loc_group.create_dataset("source", data=sofa.SourcePosition)
-            loc_group.create_dataset("receiver", data=sofa.ReceiverPosition)
-            meta_group = f.create_group("metadata")
-            meta_group.create_dataset("sampling_rate", data=sofa.Data_SamplingRate)
-
-            # Add other metadata if present
-            if hasattr(sofa, "RoomTemperature"):
-                meta_group.create_dataset("temperature", data=sofa.RoomTemperature)
-
-        return output_path
-
-    def _lookup(
-        self,
-        file_name: str,
-        cache_dir: Path,
-        export_dir: Path | None,
-    ) -> Path | None:
+    def _lookup(self, file_name: str, cache_dir: Path, export_dir: Path | None) -> Path | None:
         """Return the path if the file exists in export_dir or cache_dir, else None.
 
         Searches export_dir first, falling back to cache_dir.
@@ -375,3 +321,168 @@ output_format : str
         if p.exists():
             return p
         return None
+
+    def _move_to_export(self, source: Path, export_dir: Path) -> Path:
+        """Move file from source to export_dir.
+
+        Parameters
+        ----------
+        source : :class:`pathlib.Path`
+            Source file path.
+        export_dir : :class:`pathlib.Path`
+            Target export directory.
+
+        Returns
+        -------
+        :class:`pathlib.Path`
+            Path to the file in export_dir.
+        """
+        import shutil
+
+        target = Path(export_dir) / source.name
+        # file exists already in export_dir
+        if target.exists():
+            return target
+        # move file from source to export_dir
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(source, target)
+
+        return target
+
+    def _to_output(self, sofa: sf.Sofa, output_format: str, output_path: Path | None) -> Any:
+        """Convert :class:`sofar.Sofa` to the requested output format.
+
+        Parameters
+        ----------
+        sofa : :class:`sofar.Sofa`
+            SOFA object to convert.
+        output_format : :class:`str`
+            One of "pyfar", "numpy", "hdf5", "sofa".
+        output_path : :class:`pathlib.Path` or :class:`None`
+            Path where file-based outputs should be written.
+
+        Returns
+        -------
+        :class:`Any`
+            Output depends on output_format:
+            - "pyfar" : :class:`dict` of pyfar objects
+            - "numpy" : :class:`dict` of numpy arrays
+            - "hdf5" : :class:`pathlib.Path` to .h5 file
+            - "sofa" : :class:`pathlib.Path` to .sofa file
+        """
+        if output_format == "pyfar":
+            return self._to_pyfar(sofa)
+        elif output_format == "numpy":
+            return self._to_numpy(sofa)
+        elif output_format == "sofa":
+            return self._to_sofa(sofa, output_path)
+        elif output_format == "hdf5":
+            return self._to_hdf5(sofa, output_path)
+        else:
+            raise ValueError(f"Unknown output_format: {output_format}")
+
+    def _to_pyfar(self, sofa: sf.Sofa) -> dict:
+        """Convert :class:`sofar.Sofa` to :class:`dict` of pyfar objects.
+
+        Parameters
+        ----------
+        sofa : :class:`sofar.Sofa`
+            SOFA object to convert.
+
+        Returns
+        -------
+        :class:`dict`
+            Dictionary with keys:
+            - "impulse_response" : :class:`pyfar.Signal`
+            - "source_coordinates" : :class:`pyfar.Coordinates`
+            - "receiver_coordinates" : :class:`pyfar.Coordinates`
+        """
+        return {
+            "impulse_response": pf.Signal(sofa.Data_IR, sampling_rate=sofa.Data_SamplingRate),
+            "source_coordinates": pf.Coordinates(*sofa.SourcePosition.T),
+            "receiver_coordinates": pf.Coordinates(*sofa.ReceiverPosition.T),
+        }
+
+    def _to_numpy(self, sofa: sf.Sofa) -> dict:
+        """Convert :class:`sofar.Sofa` to :class:`dict` of numpy arrays.
+
+        Parameters
+        ----------
+        sofa : :class:`sofar.Sofa`
+            SOFA object to convert.
+
+        Returns
+        -------
+        :class:`dict`
+            Dictionary with keys:
+            - "impulse_response" : :class:`numpy.ndarray`
+            - "source_coordinates" : :class:`numpy.ndarray`
+            - "receiver_coordinates" : :class:`numpy.ndarray`
+            - "sampling_rate" : :class:`float`
+        """
+        return {
+            "impulse_response": np.array(sofa.Data_IR),
+            "source_coordinates": np.array(sofa.SourcePosition),
+            "receiver_coordinates": np.array(sofa.ReceiverPosition),
+            "sampling_rate": float(sofa.Data_SamplingRate),
+        }
+
+    def _to_sofa(self, sofa: sf.Sofa, output_path: Path) -> Path:
+        """Write :class:`sofar.Sofa` to file and return :class:`pathlib.Path`.
+
+        Parameters
+        ----------
+        sofa : :class:`sofar.Sofa`
+            SOFA object to write.
+        output_path : :class:`pathlib.Path`
+            Path where the .sofa file should be written.
+
+        Returns
+        -------
+        :class:`pathlib.Path`
+            Path to the written SOFA file.
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write_sofa(str(output_path), sofa)
+        return output_path
+
+    def _to_hdf5(self, sofa: sf.Sofa, output_path: Path) -> Path:
+        """Convert :class:`sofar.Sofa` to HDF5 file and return :class:`pathlib.Path`.
+
+        Parameters
+        ----------
+        sofa : :class:`sofar.Sofa`
+            SOFA object to convert.
+        output_path : :class:`pathlib.Path`
+            Path where the .h5 file should be written.
+
+        Returns
+        -------
+        :class:`pathlib.Path`
+            Path to the written HDF5 file.
+        """
+        import h5py as h5
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with h5.File(output_path, "w") as f:
+            # Create data group
+            data_group = f.create_group("data")
+            data_group.create_dataset("impulse_response", data=sofa.Data_IR)
+
+            # Create location group
+            loc_group = data_group.create_group("location")
+            loc_group.create_dataset("source", data=sofa.SourcePosition)
+            loc_group.create_dataset("receiver", data=sofa.ReceiverPosition)
+
+            # Create metadata group
+            meta_group = f.create_group("metadata")
+            meta_group.create_dataset("sampling_rate", data=sofa.Data_SamplingRate)
+
+            # Add other metadata if present
+            if hasattr(sofa, "RoomTemperature"):
+                meta_group.create_dataset("temperature", data=sofa.RoomTemperature)
+            if hasattr(sofa, "Data_Humidity"):
+                meta_group.create_dataset("humidity", data=sofa.Data_Humidity)
+
+        return output_path

--- a/src/irdl/base.py
+++ b/src/irdl/base.py
@@ -6,8 +6,7 @@ for all Dataset implementations. Each Dataset subclass must implement:
 - validate_params()
 - download()
 - ingest()
-- _construct_file_name()
-- _output_path()
+- _source_filename()
 
 The BaseDataset class handles:
 
@@ -41,10 +40,8 @@ class BaseDataset(ABC):
         Download and return :class:`pathlib.Path` to raw file.
     - ingest(file_path: Path) -> sofar.Sofa
         Convert raw file to :class:`sofar.Sofa` object.
-    - _construct_file_name(**kwargs) -> str
-        Construct the file name for raw input files.
-    - _output_path(output_format, cache_dir, export_dir, **kwargs) -> Path or None
-        Canonical path for output files; None for in-memory formats.
+    - _source_filename(**kwargs) -> str
+        Construct the raw input filename with extension.
     - get() @classmethod
         Public entry point with explicit type signature for CLI auto-generation.
     """
@@ -195,11 +192,49 @@ output_format : str
         raise NotImplementedError(f"{self.__class__.__name__} must implement ingest()")
 
     @abstractmethod
+    def _source_filename(self, **kwargs) -> str:
+        """Construct the raw input filename with extension for the dataset.
+
+        Override in subclass.
+
+        Parameters
+        ----------
+        **kwargs : :class:`dict`
+            Dataset-specific parameters used to construct the filename.
+
+        Returns
+        -------
+        :class:`str`
+            The raw input filename including extension (e.g., "A1.h5", "FABIAN_HRIR_measured_HATO_0.sofa").
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} must implement _source_filename()")
+
+    def _input_path(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
+        """Return the full path to the raw input file.
+
+        Parameters
+        ----------
+        cache_dir : :class:`pathlib.Path`
+            Cache directory.
+        export_dir : :class:`pathlib.Path` or :class:`None`
+            Optional export directory; takes priority over cache_dir.
+        **kwargs : :class:`dict`
+            Dataset-specific parameters passed to _source_filename().
+
+        Returns
+        -------
+        :class:`pathlib.Path`
+            Full path to the raw input file under '<base>/<DATASET_NAME>/'.
+        """
+        filename = self._source_filename(**kwargs)
+        base = (export_dir if export_dir is not None else cache_dir) / self.name.upper()
+        return base / filename
+
     def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
         """Return the canonical Path where a file-based output would be written.
 
-        Returns None for in-memory formats ('pyfar', 'numpy'). Subclasses
-        override to encode dataset-specific naming for file-based formats.
+        Returns None for in-memory formats ('pyfar', 'numpy'). Uses _source_filename
+        to construct the base filename, then replaces the extension based on output_format.
 
         Parameters
         ----------
@@ -210,14 +245,33 @@ output_format : str
         export_dir : Path or None
             Optional export directory; takes priority over cache_dir.
         **kwargs
-            Dataset-specific parameters used to construct the file name.
+            Dataset-specific parameters used to construct the filename.
 
         Returns
         -------
         Path or None
-            Canonical output path, or None for in-memory formats.
+            Canonical output path under '<base>/<DATASET_NAME>/', or None for
+            in-memory formats.
         """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement _output_path()")
+        if output_format in ("pyfar", "numpy"):
+            return None
+
+        source_filename = self._source_filename(**kwargs)
+        stem = Path(source_filename).stem
+
+        # Determine extension based on output format
+        if output_format == "sofa":
+            ext = ".sofa"
+        elif output_format == "hdf5":
+            ext = ".h5"
+        elif output_format == "raw":
+            # Keep original extension for raw output
+            ext = Path(source_filename).suffix
+        else:
+            return None
+
+        base = (export_dir if export_dir is not None else cache_dir) / self.name.upper()
+        return base / f"{stem}{ext}"
 
     def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
         """Check cache or download file.
@@ -236,10 +290,10 @@ output_format : str
         file_path : :class:`pathlib.Path`
             Path to the file on disk (either cached or newly downloaded).
         """
-        # Construct expected file name based on Dataset (subclass must implement)
-        file_name = self._construct_file_name(**kwargs)
-        file_cache = cache_dir / file_name
-        file_export = Path(export_dir) / file_name if export_dir else None
+        # Get the full input path (subclass must implement _source_filename)
+        file_path = self._input_path(cache_dir, export_dir, **kwargs)
+        file_cache = file_path
+        file_export = file_path if export_dir is not None else None
 
         # Check if file exists in export_dir or cache_dir
         if file_export is not None and file_export.exists():
@@ -276,23 +330,7 @@ output_format : str
         """
         return file_path
 
-    @abstractmethod
-    def _construct_file_name(self, **kwargs) -> str:
-        """Construct the file name for raw input files.
 
-        Override in subclass.
-
-        Parameters
-        ----------
-        **kwargs : :class:`dict`
-            Dataset-specific parameters used to construct the file name.
-
-        Returns
-        -------
-        :class:`str`
-            The constructed file name.
-        """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement _construct_file_name()")
 
     def _lookup(self, file_name: str, cache_dir: Path, export_dir: Path | None) -> Path | None:
         """Return the path if the file exists in export_dir or cache_dir, else None.

--- a/src/irdl/base.py
+++ b/src/irdl/base.py
@@ -1,56 +1,51 @@
 """Base Dataset class and conversion utilities for IRDL.
 
-This module provides the BaseDataset abstract base class which serves as the common interface
-for all Dataset implementations. Each Dataset subclass must implement:
-
-- validate_params()
-- download()
-- ingest()
-- _construct_file_name()
-- _output_path()
-
-The BaseDataset class handles:
-
-- Common parameter extraction
-- Path construction
-- Cache checking
-- Output format conversion from SOFA
+Provides the BaseDataset class that defines the common interface and pipeline
+shared by all dataset implementations. Subclasses implement dataset-specific
+logic for parameter validation, file retrieval, ingestion, and output naming.
 """
 
-from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pyfar as pf
 import sofar as sf
+import h5py as h5
+import shutil
+
+# Import CACHE_DIR from downloader to maintain consistency
+from irdl.downloader import CACHE_DIR
 
 
-class BaseDataset(ABC):
-    """Abstract base class providing common interface for all Dataset implementations.
+class BaseDataset:
+    """Common interface and pipeline for all dataset implementations.
 
-    Subclasses must implement the following abstract methods:
+    Subclasses must define:
 
-    - name : :class:`str`
-        Unique identifier for the Dataset.
-    - doi : :class:`str`
-        Digital Object Identifier for the Dataset.
+    - name : str
+        Unique identifier for the dataset.
+    - doi : str
+        Digital Object Identifier for the dataset.
+    - raw_format : str
+        Native file format of the publisher's raw files (e.g. 'hdf5' for ISTA,
+        'sofa' for FABIAN). Used to short-circuit the pipeline when the
+        requested output format matches the raw format.
     - validate_params(**dataset_kwargs)
-        Validate dataset-specific parameters (including output_format).
-    - download(**kwargs) -> Path
-        Download and return :class:`pathlib.Path` to raw file.
-    - ingest(file_path: Path) -> sofar.Sofa
-        Convert raw file to :class:`sofar.Sofa` object.
-    - _construct_file_name(**kwargs) -> str
-        Construct the file name for raw input files.
+        Validate dataset-specific parameters.
+    - _get_file(cache_dir, export_dir, **kwargs) -> Path
+        Fetch and process the raw file; return the path ready for ingest().
+    - ingest(file_path) -> sofar.Sofa
+        Convert the raw file into a SOFA object.
     - _output_path(output_format, cache_dir, export_dir, **kwargs) -> Path or None
-        Canonical path for output files; None for in-memory formats.
+        Canonical path where output is written; None for in-memory formats.
     - get() @classmethod
-        Public entry point with explicit type signature for CLI auto-generation.
+        Public entry point with an explicit signature for CLI auto-generation.
     """
 
     name: str
     doi: str
+    raw_format: str 
 
     # Default docstring prefix for all get() classmethods
     _get_doc_prefix = """Download {name} dataset.
@@ -68,35 +63,43 @@ output_format : str
 """
 
     def __init_subclass__(cls, **kwargs):
-        """Initialize subclass with automatic docstring composition for get() classmethod."""
         super().__init_subclass__(**kwargs)
         # Automatically compose docstrings for get() classmethod
-        if hasattr(cls, "get") and hasattr(cls, "name") and hasattr(cls, "doi"):
+        if hasattr(cls, 'get') and hasattr(cls, 'name') and hasattr(cls, 'doi'):
             # Get the underlying function of the classmethod
             get_func = cls.get.__func__
             # Format prefix with class attributes
-            prefix = BaseDataset._get_doc_prefix.format(name=cls.name, doi=cls.doi)
+            prefix = BaseDataset._get_doc_prefix.format(
+                name=cls.name,
+                doi=cls.doi
+            )
             # Get subclass-specific docstring
             suffix = get_func.__doc__ or ""
             # Combine: prefix + suffix
             full_doc = prefix
             if suffix:
-                if not full_doc.endswith("\n\n"):
-                    full_doc += "\n\n"
+                if not full_doc.endswith('\n\n'):
+                    full_doc += '\n\n'
                 full_doc += suffix
             get_func.__doc__ = full_doc
 
-    def _get(self, *, cache_dir: str, export_dir: str | None, output_format: str, **dataset_kwargs) -> Any:
-        """Internal implementation of Dataset retrieval.
+    def _get(self, *, cache_dir: str, export_dir: str | None,
+             output_format: str, **dataset_kwargs) -> Any:
+        """Execute the full dataset retrieval pipeline.
+
+        Validates parameters, returns an existing output if found, otherwise
+        fetches and processes the raw file, ingests it to SOFA, and converts
+        to the requested output format.
 
         Parameters
         ----------
         cache_dir : str
-            Cache directory for downloads.
-        export_dir : str, optional
-            Directory for final output.
+            Cache directory for downloads and intermediate files.
+        export_dir : str or None
+            Optional directory for final output. If None, files stay in
+            cache_dir.
         output_format : str
-            Output format: 'pyfar', 'numpy', 'hdf5', 'sofa', or 'raw'.
+            One of 'pyfar', 'numpy', 'hdf5', 'sofa', 'raw'.
         **dataset_kwargs
             Dataset-specific parameters.
 
@@ -113,88 +116,28 @@ output_format : str
         if output_format not in ("pyfar", "hdf5", "numpy", "sofa", "raw"):
             raise ValueError("output_format must be one of 'pyfar', 'hdf5', 'numpy', 'sofa', 'raw'")
 
-        # Validate dataset-specific parameters (including output_format)
-        self.validate_params(output_format=output_format, **dataset_kwargs)
+        # Validate dataset-specific parameters
+        self.validate_params(**dataset_kwargs)
 
-        # Early return if output file already exists
+        # define output_path ad check if (file-based) output exists already
         output_path = self._output_path(output_format, cache_dir, export_dir, **dataset_kwargs)
         if output_path is not None and output_path.exists():
             return output_path
 
         # Get the raw file (download if needed)
-        file_path = self._get_file(cache_dir=cache_dir, export_dir=export_dir, **dataset_kwargs)
+        file_path = self._get_file(cache_dir, export_dir, **dataset_kwargs)
 
         # For raw output, return the file directly without processing
-        if output_format == "raw":
+        if output_format == "raw" or output_format == self.raw_format:
             return file_path
 
-        # Process the file if needed (e.g., extraction, merging)
-        processed_path = self._process(file_path, **dataset_kwargs)
-
         # Ingest to SOFA (internal standard)
-        sofa = self.ingest(processed_path)
+        sofa = self.ingest(file_path)
 
         # Convert to requested output format
         return self._to_output(sofa, output_format, output_path)
 
-    @abstractmethod
-    def validate_params(self, **dataset_kwargs) -> None:
-        """Validate dataset-specific parameters.
 
-        Override in subclass. This method receives dataset-specific parameters
-        plus ``output_format`` (so subclasses can forbid invalid output_format /
-        dataset-parameter combinations).
-
-        Parameters
-        ----------
-        **dataset_kwargs
-            Dataset-specific parameters to validate, including ``output_format``.
-
-        Raises
-        ------
-        ValueError
-            If any parameter is invalid.
-        """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement validate_params()")
-
-    @abstractmethod
-    def download(self, **kwargs) -> Path:
-        """Download raw files and return :class:`pathlib.Path` to the primary file.
-
-        Override in subclass.
-
-        Parameters
-        ----------
-        **kwargs : :class:`dict`
-            Dataset-specific parameters (scenario, kind, hato, etc.).
-            cache_dir and export_dir are NOT in kwargs (handled by _get_file()).
-
-        Returns
-        -------
-        file_path : :class:`pathlib.Path`
-            Path to the downloaded/processed file on disk.
-        """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement download()")
-
-    @abstractmethod
-    def ingest(self, file_path: Path) -> sf.Sofa:
-        """Convert raw file to :class:`sofar.Sofa` object.
-
-        Override in subclass.
-
-        Parameters
-        ----------
-        file_path : :class:`pathlib.Path`
-            Path to the file returned by _get_file().
-
-        Returns
-        -------
-        sofa : :class:`sofar.Sofa`
-            SOFA object representing the Dataset data.
-        """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement ingest()")
-
-    @abstractmethod
     def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
         """Return the canonical Path where a file-based output would be written.
 
@@ -217,84 +160,201 @@ output_format : str
         Path or None
             Canonical output path, or None for in-memory formats.
         """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement _output_path()")
+        return NotImplementedError(f"{self.__class__.__name__} must implement output_path)")
+  
+    def validate_params(self, **dataset_kwargs: dict) -> None:
+        """Validate dataset-specific parameters.
 
-    def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
-        """Check cache or download file.
-
-        Parameters
-        ----------
-        cache_dir : :class:`pathlib.Path`
-            Base cache directory.
-        export_dir : :class:`pathlib.Path` or :class:`None`
-            Optional export directory.
-        **kwargs : :class:`dict`
-            Dataset-specific parameters passed to download().
-
-        Returns
-        -------
-        file_path : :class:`pathlib.Path`
-            Path to the file on disk (either cached or newly downloaded).
-        """
-        # Construct expected file name based on Dataset (subclass must implement)
-        file_name = self._construct_file_name(**kwargs)
-        file_cache = cache_dir / file_name
-        file_export = Path(export_dir) / file_name if export_dir else None
-
-        # Check if file exists in export_dir or cache_dir
-        if file_export is not None and file_export.exists():
-            return file_export
-        if file_cache.exists():
-            return file_cache
-
-        # File not cached - download it
-        downloaded_path = self.download(**kwargs)
-
-        # Move to export_dir if specified and different from cache_dir
-        if export_dir is not None and export_dir != cache_dir:
-            return self._move_to_export(downloaded_path, export_dir)
-
-        return downloaded_path
-
-    def _process(self, file_path: Path, **kwargs) -> Path:
-        """Post-process downloaded file if needed.
-
-        Override in subclass to extract, transform, or otherwise process
-        the raw downloaded file before ingestion.
+        Override in subclass. Common parameters (cache_dir, export_dir,
+        output_format) are validated in _get.
 
         Parameters
         ----------
-        file_path : :class:`pathlib.Path`
-            Path to the raw downloaded file.
-        **kwargs : :class:`dict`
-            Dataset-specific parameters (may be needed for processing decisions).
+        **dataset_kwargs
+            Dataset-specific parameters to validate.
+
+        Raises
+        ------
+        ValueError
+            If any parameter is invalid.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} must implement validate_params()")
+
+    def _get_file(self, cache_dir, export_dir, **kwargs) -> Path:
+        """Return the path to a file ready for ingest().
+
+        Subclass implements the input-side flow: check cache, download what is
+        missing, perform any merging or splitting, return the final path.
+
+        Parameters
+        ----------
+        cache_dir : Path
+            Cache directory for downloads.
+        export_dir : Path or None
+            Optional directory for final output; takes priority over cache_dir
+            for writes.
+        **kwargs
+            Dataset-specific parameters.
 
         Returns
         -------
-        file_path : :class:`pathlib.Path`
-            Path to the processed file (may be same as input if no processing needed).
+        Path
+            Path to the file ready to be passed to ingest().
         """
-        return file_path
+        raise NotImplementedError(f"{self.__class__.__name__} must implement _get_file()")
 
-    @abstractmethod
-    def _construct_file_name(self, **kwargs) -> str:
-        """Construct the file name for raw input files.
+    def ingest(self, file_path: Path) -> sf.Sofa:
+        """Convert a raw file into a sofar.Sofa object.
 
         Override in subclass.
 
         Parameters
         ----------
-        **kwargs : :class:`dict`
-            Dataset-specific parameters used to construct the file name.
+        file_path : Path
+            Path to the file returned by _get_file().
 
         Returns
         -------
-        :class:`str`
-            The constructed file name.
+        sofar.Sofa
+            SOFA object representing the dataset.
         """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement _construct_file_name()")
+        raise NotImplementedError(f"{self.__class__.__name__} must implement ingest()")
 
-    def _lookup(self, file_name: str, cache_dir: Path, export_dir: Path | None) -> Path | None:
+
+    def _to_output(self, sofa: sf.Sofa, output_format: str, output_path: Path) -> Any:
+        """Dispatch a sofar.Sofa object to the requested output format.
+
+        Parameters
+        ----------
+        sofa : sofar.Sofa
+            SOFA object to convert.
+        output_format : str
+            One of 'pyfar', 'numpy', 'hdf5', 'sofa'.
+        output_path : Path
+            Where to write file-based outputs ('sofa', 'hdf5'). Ignored for
+            in-memory formats ('pyfar', 'numpy').
+
+        Returns
+        -------
+        dict or Path
+            'pyfar' / 'numpy': dict of in-memory objects.
+            'sofa' / 'hdf5': Path to the written file.
+        """
+        if output_format == "pyfar":
+            return self._to_pyfar(sofa)
+        if output_format == "numpy":
+            return self._to_numpy(sofa)
+        if output_format == "sofa":
+            return self._to_sofa(sofa, output_path)
+        if output_format == "hdf5":
+            return self._to_hdf5(sofa, output_path)
+
+    def _to_pyfar(self, sofa: sf.Sofa) -> dict:
+        """Convert a sofar.Sofa object into a dict of pyfar objects.
+
+        Parameters
+        ----------
+        sofa : sofar.Sofa
+            SOFA object to convert.
+
+        Returns
+        -------
+        dict
+            Keys:
+            - 'impulse_response' : pyfar.Signal
+            - 'source_coordinates' : pyfar.Coordinates
+            - 'receiver_coordinates' : pyfar.Coordinates
+        """
+        return {
+            "impulse_response": pf.Signal(sofa.Data_IR, sampling_rate=sofa.Data_SamplingRate),
+            "source_coordinates": pf.Coordinates(*sofa.SourcePosition.T),
+            "receiver_coordinates": pf.Coordinates(*sofa.ReceiverPosition.T),
+        }
+
+    def _to_numpy(self, sofa: sf.Sofa) -> dict:
+        """Convert a sofar.Sofa object into a dict of numpy arrays.
+
+        Parameters
+        ----------
+        sofa : sofar.Sofa
+            SOFA object to convert.
+
+        Returns
+        -------
+        dict
+            Keys:
+            - 'impulse_response' : numpy.ndarray
+            - 'source_coordinates' : numpy.ndarray
+            - 'receiver_coordinates' : numpy.ndarray
+            - 'sampling_rate' : float
+        """
+        return {
+            "impulse_response": np.array(sofa.Data_IR),
+            "source_coordinates": np.array(sofa.SourcePosition),
+            "receiver_coordinates": np.array(sofa.ReceiverPosition),
+            "sampling_rate": float(sofa.Data_SamplingRate),
+        }
+
+    def _to_sofa(self, sofa: sf.Sofa, output_path: Path) -> Path:
+        """Write a sofar.Sofa object to a .sofa file.
+
+        Parameters
+        ----------
+        sofa : sofar.Sofa
+            SOFA object to write.
+        output_path : Path
+            Path where the .sofa file is written.
+
+        Returns
+        -------
+        Path
+            Path to the written .sofa file.
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write_sofa(str(output_path), sofa)
+        return output_path
+    
+
+    def _to_hdf5(self, sofa: sf.Sofa, output_path: Path) -> Path:
+        """Write a sofar.Sofa object as an HDF5 file.
+
+        Parameters
+        ----------
+        sofa : sofar.Sofa
+            SOFA object to write.
+        output_path : Path
+            Path where the .h5 file is written.
+
+        Returns
+        -------
+        Path
+            Path to the written .h5 file.
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+    
+        with h5.File(output_path, "w") as f:
+            data_group = f.create_group("data")
+            data_group.create_dataset("impulse_response", data=sofa.Data_IR)
+            loc_group = data_group.create_group("location")
+            loc_group.create_dataset("source", data=sofa.SourcePosition)
+            loc_group.create_dataset("receiver", data=sofa.ReceiverPosition)
+            meta_group = f.create_group("metadata")
+            meta_group.create_dataset("sampling_rate", data=sofa.Data_SamplingRate)
+
+            # Add other metadata if present
+            if hasattr(sofa, "Data_Temperature"):
+                meta_group.create_dataset("temperature", data=sofa.Data_Temperature)
+            if hasattr(sofa, "Data_Humidity"):
+                meta_group.create_dataset("humidity", data=sofa.Data_Humidity)
+        
+        return output_path
+
+    def _lookup(
+        self,
+        file_name: str,
+        cache_dir: Path,
+        export_dir: Path | None,
+    ) -> Path | None:
         """Return the path if the file exists in export_dir or cache_dir, else None.
 
         Searches export_dir first, falling back to cache_dir.
@@ -321,168 +381,3 @@ output_format : str
         if p.exists():
             return p
         return None
-
-    def _move_to_export(self, source: Path, export_dir: Path) -> Path:
-        """Move file from source to export_dir.
-
-        Parameters
-        ----------
-        source : :class:`pathlib.Path`
-            Source file path.
-        export_dir : :class:`pathlib.Path`
-            Target export directory.
-
-        Returns
-        -------
-        :class:`pathlib.Path`
-            Path to the file in export_dir.
-        """
-        import shutil
-
-        target = Path(export_dir) / source.name
-        # file exists already in export_dir
-        if target.exists():
-            return target
-        # move file from source to export_dir
-        target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(source, target)
-
-        return target
-
-    def _to_output(self, sofa: sf.Sofa, output_format: str, output_path: Path | None) -> Any:
-        """Convert :class:`sofar.Sofa` to the requested output format.
-
-        Parameters
-        ----------
-        sofa : :class:`sofar.Sofa`
-            SOFA object to convert.
-        output_format : :class:`str`
-            One of "pyfar", "numpy", "hdf5", "sofa".
-        output_path : :class:`pathlib.Path` or :class:`None`
-            Path where file-based outputs should be written.
-
-        Returns
-        -------
-        :class:`Any`
-            Output depends on output_format:
-            - "pyfar" : :class:`dict` of pyfar objects
-            - "numpy" : :class:`dict` of numpy arrays
-            - "hdf5" : :class:`pathlib.Path` to .h5 file
-            - "sofa" : :class:`pathlib.Path` to .sofa file
-        """
-        if output_format == "pyfar":
-            return self._to_pyfar(sofa)
-        elif output_format == "numpy":
-            return self._to_numpy(sofa)
-        elif output_format == "sofa":
-            return self._to_sofa(sofa, output_path)
-        elif output_format == "hdf5":
-            return self._to_hdf5(sofa, output_path)
-        else:
-            raise ValueError(f"Unknown output_format: {output_format}")
-
-    def _to_pyfar(self, sofa: sf.Sofa) -> dict:
-        """Convert :class:`sofar.Sofa` to :class:`dict` of pyfar objects.
-
-        Parameters
-        ----------
-        sofa : :class:`sofar.Sofa`
-            SOFA object to convert.
-
-        Returns
-        -------
-        :class:`dict`
-            Dictionary with keys:
-            - "impulse_response" : :class:`pyfar.Signal`
-            - "source_coordinates" : :class:`pyfar.Coordinates`
-            - "receiver_coordinates" : :class:`pyfar.Coordinates`
-        """
-        return {
-            "impulse_response": pf.Signal(sofa.Data_IR, sampling_rate=sofa.Data_SamplingRate),
-            "source_coordinates": pf.Coordinates(*sofa.SourcePosition.T),
-            "receiver_coordinates": pf.Coordinates(*sofa.ReceiverPosition.T),
-        }
-
-    def _to_numpy(self, sofa: sf.Sofa) -> dict:
-        """Convert :class:`sofar.Sofa` to :class:`dict` of numpy arrays.
-
-        Parameters
-        ----------
-        sofa : :class:`sofar.Sofa`
-            SOFA object to convert.
-
-        Returns
-        -------
-        :class:`dict`
-            Dictionary with keys:
-            - "impulse_response" : :class:`numpy.ndarray`
-            - "source_coordinates" : :class:`numpy.ndarray`
-            - "receiver_coordinates" : :class:`numpy.ndarray`
-            - "sampling_rate" : :class:`float`
-        """
-        return {
-            "impulse_response": np.array(sofa.Data_IR),
-            "source_coordinates": np.array(sofa.SourcePosition),
-            "receiver_coordinates": np.array(sofa.ReceiverPosition),
-            "sampling_rate": float(sofa.Data_SamplingRate),
-        }
-
-    def _to_sofa(self, sofa: sf.Sofa, output_path: Path) -> Path:
-        """Write :class:`sofar.Sofa` to file and return :class:`pathlib.Path`.
-
-        Parameters
-        ----------
-        sofa : :class:`sofar.Sofa`
-            SOFA object to write.
-        output_path : :class:`pathlib.Path`
-            Path where the .sofa file should be written.
-
-        Returns
-        -------
-        :class:`pathlib.Path`
-            Path to the written SOFA file.
-        """
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        sf.write_sofa(str(output_path), sofa)
-        return output_path
-
-    def _to_hdf5(self, sofa: sf.Sofa, output_path: Path) -> Path:
-        """Convert :class:`sofar.Sofa` to HDF5 file and return :class:`pathlib.Path`.
-
-        Parameters
-        ----------
-        sofa : :class:`sofar.Sofa`
-            SOFA object to convert.
-        output_path : :class:`pathlib.Path`
-            Path where the .h5 file should be written.
-
-        Returns
-        -------
-        :class:`pathlib.Path`
-            Path to the written HDF5 file.
-        """
-        import h5py as h5
-
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-        with h5.File(output_path, "w") as f:
-            # Create data group
-            data_group = f.create_group("data")
-            data_group.create_dataset("impulse_response", data=sofa.Data_IR)
-
-            # Create location group
-            loc_group = data_group.create_group("location")
-            loc_group.create_dataset("source", data=sofa.SourcePosition)
-            loc_group.create_dataset("receiver", data=sofa.ReceiverPosition)
-
-            # Create metadata group
-            meta_group = f.create_group("metadata")
-            meta_group.create_dataset("sampling_rate", data=sofa.Data_SamplingRate)
-
-            # Add other metadata if present
-            if hasattr(sofa, "RoomTemperature"):
-                meta_group.create_dataset("temperature", data=sofa.RoomTemperature)
-            if hasattr(sofa, "Data_Humidity"):
-                meta_group.create_dataset("humidity", data=sofa.Data_Humidity)
-
-        return output_path

--- a/src/irdl/base.py
+++ b/src/irdl/base.py
@@ -7,6 +7,7 @@ for all Dataset implementations. Each Dataset subclass must implement:
 - download()
 - ingest()
 - _construct_file_name()
+- _output_path()
 
 The BaseDataset class handles:
 
@@ -34,21 +35,18 @@ class BaseDataset(ABC):
         Unique identifier for the Dataset.
     - doi : :class:`str`
         Digital Object Identifier for the Dataset.
-    - validate_params(dataset_kwargs: dict)
-        Validate dataset-specific parameters only (no common params).
+    - validate_params(**dataset_kwargs)
+        Validate dataset-specific parameters (including output_format).
     - download(**kwargs) -> Path
         Download and return :class:`pathlib.Path` to raw file.
     - ingest(file_path: Path) -> sofar.Sofa
         Convert raw file to :class:`sofar.Sofa` object.
+    - _construct_file_name(**kwargs) -> str
+        Construct the file name for raw input files.
+    - _output_path(output_format, cache_dir, export_dir, **kwargs) -> Path or None
+        Canonical path for output files; None for in-memory formats.
     - get() @classmethod
         Public entry point with explicit type signature for CLI auto-generation.
-
-    Subclasses may override:
-
-    - validate_output_format(output_format: str, **dataset_kwargs)
-        Dataset-specific validation of output_format in context of dataset params.
-    - _get(**dataset_kwargs)
-        For datasets with special handling (e.g., FABIAN raw output).
     """
 
     name: str
@@ -104,8 +102,9 @@ output_format : str
 
         Returns
         -------
-        data : dict or pathlib.Path
-            Returned data depends on output_format.
+        dict or Path
+            For 'pyfar' / 'numpy': a dict of in-memory objects.
+            For 'sofa' / 'hdf5' / 'raw': a Path to the file on disk.
         """
         cache_dir = Path(cache_dir)
         export_dir = Path(export_dir) if export_dir else None
@@ -114,55 +113,47 @@ output_format : str
         if output_format not in ("pyfar", "hdf5", "numpy", "sofa", "raw"):
             raise ValueError("output_format must be one of 'pyfar', 'hdf5', 'numpy', 'sofa', 'raw'")
 
-        # Validate dataset-specific parameters
-        self.validate_params(dataset_kwargs)
+        # Validate dataset-specific parameters (including output_format)
+        self.validate_params(output_format=output_format, **dataset_kwargs)
 
-        # Dataset-specific output_format validation (e.g., SRIRACHA raw restrictions)
-        self.validate_output_format(output_format, **dataset_kwargs)
+        # Early return if output file already exists
+        output_path = self._output_path(output_format, cache_dir, export_dir, **dataset_kwargs)
+        if output_path is not None and output_path.exists():
+            return output_path
 
-        # Steps 2-3: Get the raw file (download if needed)
+        # Get the raw file (download if needed)
         file_path = self._get_file(cache_dir=cache_dir, export_dir=export_dir, **dataset_kwargs)
 
         # For raw output, return the file directly without processing
         if output_format == "raw":
             return file_path
 
-        # For non-raw: process the file if needed, then ingest and convert
+        # Process the file if needed (e.g., extraction, merging)
         processed_path = self._process(file_path, **dataset_kwargs)
 
         # Ingest to SOFA (internal standard)
         sofa = self.ingest(processed_path)
 
         # Convert to requested output format
-        return self._to_output(sofa, output_format, cache_dir, export_dir)
-
-    def validate_output_format(self, output_format: str, **dataset_kwargs) -> None:  # noqa: B027
-        """Validate output_format in the context of dataset-specific parameters.
-
-        Override in subclasses that have output_format restrictions
-        (e.g., SRIRACHA blocks raw for non-dense scenarios).
-
-        Parameters
-        ----------
-        output_format : str
-            The output format to validate.
-        **dataset_kwargs
-            Dataset-specific parameters that may affect validation.
-        """
-        ...
+        return self._to_output(sofa, output_format, output_path)
 
     @abstractmethod
-    def validate_params(self, dataset_kwargs: dict) -> None:
-        """Validate dataset-specific parameters only.
+    def validate_params(self, **dataset_kwargs) -> None:
+        """Validate dataset-specific parameters.
 
-        Override in subclass. This method receives only dataset-specific
-        parameters (scenario, dataset_split, kind, hato, etc.) — common
-        parameters have already been extracted and validated.
+        Override in subclass. This method receives dataset-specific parameters
+        plus ``output_format`` (so subclasses can forbid invalid output_format /
+        dataset-parameter combinations).
 
         Parameters
         ----------
-        dataset_kwargs : dict
-            Dataset-specific parameters to validate.
+        **dataset_kwargs
+            Dataset-specific parameters to validate, including ``output_format``.
+
+        Raises
+        ------
+        ValueError
+            If any parameter is invalid.
         """
         raise NotImplementedError(f"{self.__class__.__name__} must implement validate_params()")
 
@@ -176,7 +167,7 @@ output_format : str
         ----------
         **kwargs : :class:`dict`
             Dataset-specific parameters (scenario, kind, hato, etc.).
-            cache_dir and export_dir are NOT in kwargs (handled by get()).
+            cache_dir and export_dir are NOT in kwargs (handled by _get_file()).
 
         Returns
         -------
@@ -194,7 +185,7 @@ output_format : str
         Parameters
         ----------
         file_path : :class:`pathlib.Path`
-            Path to the file returned by download().
+            Path to the file returned by _get_file().
 
         Returns
         -------
@@ -202,6 +193,31 @@ output_format : str
             SOFA object representing the Dataset data.
         """
         raise NotImplementedError(f"{self.__class__.__name__} must implement ingest()")
+
+    @abstractmethod
+    def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
+        """Return the canonical Path where a file-based output would be written.
+
+        Returns None for in-memory formats ('pyfar', 'numpy'). Subclasses
+        override to encode dataset-specific naming for file-based formats.
+
+        Parameters
+        ----------
+        output_format : str
+            One of 'pyfar', 'numpy', 'hdf5', 'sofa', 'raw'.
+        cache_dir : Path
+            Cache directory.
+        export_dir : Path or None
+            Optional export directory; takes priority over cache_dir.
+        **kwargs
+            Dataset-specific parameters used to construct the file name.
+
+        Returns
+        -------
+        Path or None
+            Canonical output path, or None for in-memory formats.
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} must implement _output_path()")
 
     def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
         """Check cache or download file.
@@ -220,7 +236,7 @@ output_format : str
         file_path : :class:`pathlib.Path`
             Path to the file on disk (either cached or newly downloaded).
         """
-        # Construct expected file name based on Dataset (subclass can override)
+        # Construct expected file name based on Dataset (subclass must implement)
         file_name = self._construct_file_name(**kwargs)
         file_cache = cache_dir / file_name
         file_export = Path(export_dir) / file_name if export_dir else None
@@ -232,10 +248,10 @@ output_format : str
             return file_cache
 
         # File not cached - download it
-        downloaded_path = self.download(cache_dir=cache_dir, **kwargs)
+        downloaded_path = self.download(**kwargs)
 
-        # Move to export_dir if specified
-        if export_dir is not None:
+        # Move to export_dir if specified and different from cache_dir
+        if export_dir is not None and export_dir != cache_dir:
             return self._move_to_export(downloaded_path, export_dir)
 
         return downloaded_path
@@ -262,9 +278,9 @@ output_format : str
 
     @abstractmethod
     def _construct_file_name(self, **kwargs) -> str:
-        """Construct the file name for this Dataset.
+        """Construct the file name for raw input files.
 
-        Override in subclass if needed.
+        Override in subclass.
 
         Parameters
         ----------
@@ -276,6 +292,35 @@ output_format : str
         :class:`str`
             The constructed file name.
         """
+        raise NotImplementedError(f"{self.__class__.__name__} must implement _construct_file_name()")
+
+    def _lookup(self, file_name: str, cache_dir: Path, export_dir: Path | None) -> Path | None:
+        """Return the path if the file exists in export_dir or cache_dir, else None.
+
+        Searches export_dir first, falling back to cache_dir.
+
+        Parameters
+        ----------
+        file_name : str
+            File name to search for.
+        cache_dir : Path
+            Cache directory to search.
+        export_dir : Path or None
+            Optional export directory to search first.
+
+        Returns
+        -------
+        Path or None
+            Path to the existing file, or None if not found.
+        """
+        if export_dir is not None:
+            p = export_dir / file_name
+            if p.exists():
+                return p
+        p = cache_dir / file_name
+        if p.exists():
+            return p
+        return None
 
     def _move_to_export(self, source: Path, export_dir: Path) -> Path:
         """Move file from source to export_dir.
@@ -292,11 +337,19 @@ output_format : str
         :class:`pathlib.Path`
             Path to the file in export_dir.
         """
-        from irdl.utils import _move_to_export_dir
+        import shutil
 
-        return _move_to_export_dir(source, str(export_dir))
+        target = Path(export_dir) / source.name
+        # file exists already in export_dir
+        if target.exists():
+            return target
+        # move file from source to export_dir
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(source, target)
 
-    def _to_output(self, sofa: sf.Sofa, output_format: str, cache_dir: Path, export_dir: Path | None) -> Any:
+        return target
+
+    def _to_output(self, sofa: sf.Sofa, output_format: str, output_path: Path | None) -> Any:
         """Convert :class:`sofar.Sofa` to the requested output format.
 
         Parameters
@@ -305,10 +358,8 @@ output_format : str
             SOFA object to convert.
         output_format : :class:`str`
             One of "pyfar", "numpy", "hdf5", "sofa".
-        cache_dir : :class:`pathlib.Path`
-            Cache directory for file-based outputs.
-        export_dir : :class:`pathlib.Path` or :class:`None`
-            Optional export directory for file-based outputs.
+        output_path : :class:`pathlib.Path` or :class:`None`
+            Path where file-based outputs should be written.
 
         Returns
         -------
@@ -324,9 +375,9 @@ output_format : str
         elif output_format == "numpy":
             return self._to_numpy(sofa)
         elif output_format == "sofa":
-            return self._to_sofa(sofa, cache_dir, export_dir)
+            return self._to_sofa(sofa, output_path)
         elif output_format == "hdf5":
-            return self._to_hdf5(sofa, cache_dir, export_dir)
+            return self._to_hdf5(sofa, output_path)
         else:
             raise ValueError(f"Unknown output_format: {output_format}")
 
@@ -376,49 +427,34 @@ output_format : str
             "sampling_rate": float(sofa.Data_SamplingRate),
         }
 
-    def _to_sofa(self, sofa: sf.Sofa, cache_dir: Path, export_dir: Path | None) -> Path:
+    def _to_sofa(self, sofa: sf.Sofa, output_path: Path) -> Path:
         """Write :class:`sofar.Sofa` to file and return :class:`pathlib.Path`.
 
         Parameters
         ----------
         sofa : :class:`sofar.Sofa`
             SOFA object to write.
-        cache_dir : :class:`pathlib.Path`
-            Cache directory (used if export_dir is None).
-        export_dir : :class:`pathlib.Path` or :class:`None`
-            Optional export directory.
+        output_path : :class:`pathlib.Path`
+            Path where the .sofa file should be written.
 
         Returns
         -------
         :class:`pathlib.Path`
             Path to the written SOFA file.
         """
-        import sofar as sf
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.write_sofa(str(output_path), sofa)
+        return output_path
 
-        # Generate unique file name
-        file_name = f"{self.name}.sofa"
-        if export_dir:
-            path = export_dir / file_name
-        else:
-            path = cache_dir / self.name / file_name
-        path.parent.mkdir(parents=True, exist_ok=True)
-        sf.write_sofa(str(path), sofa)
-        return path
-
-    def _to_hdf5(self, sofa: sf.Sofa, cache_dir: Path, export_dir: Path | None) -> Path:
+    def _to_hdf5(self, sofa: sf.Sofa, output_path: Path) -> Path:
         """Convert :class:`sofar.Sofa` to HDF5 file and return :class:`pathlib.Path`.
-
-        TODO: Implement proper conversion to match MIRACLE/SRIRACHA structure.
-        For now, this is a placeholder that writes a basic HDF5 file.
 
         Parameters
         ----------
         sofa : :class:`sofar.Sofa`
             SOFA object to convert.
-        cache_dir : :class:`pathlib.Path`
-            Cache directory (used if export_dir is None).
-        export_dir : :class:`pathlib.Path` or :class:`None`
-            Optional export directory.
+        output_path : :class:`pathlib.Path`
+            Path where the .h5 file should be written.
 
         Returns
         -------
@@ -427,14 +463,9 @@ output_format : str
         """
         import h5py as h5
 
-        file_name = f"{self.name}.h5"
-        if export_dir:
-            path = export_dir / file_name
-        else:
-            path = cache_dir / self.name / file_name
-        path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with h5.File(path, "w") as f:
+        with h5.File(output_path, "w") as f:
             # Create data group
             data_group = f.create_group("data")
             data_group.create_dataset("impulse_response", data=sofa.Data_IR)
@@ -449,9 +480,9 @@ output_format : str
             meta_group.create_dataset("sampling_rate", data=sofa.Data_SamplingRate)
 
             # Add other metadata if present
-            if hasattr(sofa, "Data_Temperature"):
-                meta_group.create_dataset("temperature", data=sofa.Data_Temperature)
+            if hasattr(sofa, "RoomTemperature"):
+                meta_group.create_dataset("temperature", data=sofa.RoomTemperature)
             if hasattr(sofa, "Data_Humidity"):
                 meta_group.create_dataset("humidity", data=sofa.Data_Humidity)
 
-        return path
+        return output_path

--- a/src/irdl/cli.py
+++ b/src/irdl/cli.py
@@ -69,7 +69,7 @@ for name in irdl.__all__:
     # Set the modified signature on the underlying function
     get_method.__func__.__signature__ = sig.replace(parameters=new_params)
 
-    # Build help text (DOI already included in docstring via __init_subclass__)
+    # Build help text from docstring
     help_text = doc["Summary"][0] + "\n\n" + " ".join(doc["Extended Summary"])
 
     # Register subcommand using dataset_class.name for the command name

--- a/src/irdl/cli.py
+++ b/src/irdl/cli.py
@@ -1,40 +1,73 @@
 """Automatic generation of a Typer script for all datasets that can be used for download."""
 
+import pathlib
+import types
 from inspect import signature
-from typing import Annotated
+from typing import Annotated, Optional, Union, get_args, get_origin
 
 import typer
 from numpydoc.docscrape import FunctionDoc
 
 import irdl
 
+
+def _resolve_union_type(annotation):
+    """Resolve Union types to Typer-compatible types."""
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    # Handle types.UnionType (Python 3.10+) and typing.Union
+    if origin is types.UnionType or origin is Union:
+        # Filter out NoneType and Path types, keep str
+        non_none_args = [arg for arg in args if arg is not type(None)]
+        # If we have str and/or Path, use str (paths can be passed as strings in CLI)
+        if any(arg is str or arg is pathlib.Path or arg == pathlib.Path for arg in non_none_args):
+            # Check if None was in the original args
+            if type(None) in args:
+                return Optional[str]
+            return str
+        # For other unions, just take the first type
+        if type(None) in args:
+            return Optional[non_none_args[0]]
+        return non_none_args[0]
+
+    return annotation
+
+
 # Typer app that can be invoked by calling ``irdl`` from the CLI.
 app = typer.Typer(no_args_is_help=True)
 
 # Automatically register all supported datasets as subcommands to the app.
 for name in irdl.__all__:
-    # Skip non-Dataset items (like CACHE_DIR)
-    if name == "CACHE_DIR":
-        continue
-
     dataset_class = getattr(irdl, name)
     get_method = dataset_class.get
 
     # Get docstring and signature from the classmethod
     doc = FunctionDoc(get_method)
-    sig = signature(get_method)
+    # For classmethods, we need to get the signature from __func__ to include the cls parameter
+    # This ensures that when we set the modified signature back, it maintains the correct structure
+    sig = signature(get_method.__func__)
 
     # Build Typer parameters with help text from docstring
     # Match parameters by name to handle docstring composition ordering
     param_docs = {p.name: " ".join(p.desc).replace("`", "") for p in doc["Parameters"]}
-    typer_parameters = [
-        p.replace(annotation=Annotated[p.annotation, typer.Option(help=param_docs.get(p.name, ""))])
-        for p in sig.parameters.values()
-    ]
+
+    # Build new parameters list, preserving cls for classmethods
+    new_params = []
+    for name, p in sig.parameters.items():
+        if name == "cls":
+            # Keep cls parameter as-is (no typer.Option annotation)
+            new_params.append(p)
+        else:
+            # Add typer.Option annotation to dataset-specific parameters
+            new_params.append(
+                p.replace(
+                    annotation=Annotated[_resolve_union_type(p.annotation), typer.Option(help=param_docs.get(name, ""))]
+                )
+            )
 
     # Set the modified signature on the underlying function
-    # For classmethods, we need to set it on __func__
-    get_method.__func__.__signature__ = sig.replace(parameters=typer_parameters)
+    get_method.__func__.__signature__ = sig.replace(parameters=new_params)
 
     # Build help text (DOI already included in docstring via __init_subclass__)
     help_text = doc["Summary"][0] + "\n\n" + " ".join(doc["Extended Summary"])

--- a/src/irdl/downloader.py
+++ b/src/irdl/downloader.py
@@ -10,7 +10,7 @@ CACHE_DIR = po.os_cache("irdl")
 
 
 class RichProgressBar:
-    """Wraps :class:`rich.progress.Progress` to satisfy the pooch progress bar interface.
+    """Wrap rich.progress.Progress to satisfy the pooch progress bar interface.
 
     Pooch expects an object with a ``total`` attribute and ``update``, ``reset``, and
     ``close`` methods. This class provides that interface backed by a Rich progress bar.
@@ -33,8 +33,14 @@ class RichProgressBar:
         self.total = 0
 
     @property
-    def total(self):
-        """Total download size in bytes."""
+    def total(self) -> int:
+        """Total download size in bytes.
+
+        Returns
+        -------
+        int
+            Total download size in bytes.
+        """
         return self._total
 
     @total.setter
@@ -45,19 +51,22 @@ class RichProgressBar:
             self._progress.update(self._task_id, total=self._total or None)
 
     def update(self, n: int) -> None:
-        """Advance the progress bar by *n* bytes."""
+        """Advance the progress bar by n bytes."""
         if self._task_id is None:
             self._progress.start()
             self._task_id = self._progress.add_task(self._description, total=self.total if self.total else None)
         self._progress.advance(self._task_id, n)
 
     def reset(self) -> None:
-        """Reset the completed byte count to zero (called by pooch before the final fill)."""
+        """Reset the completed byte count to zero.
+
+        Called by pooch before the final fill.
+        """
         if self._task_id is not None:
             self._progress.reset(self._task_id, total=self.total if self.total else None)
 
     def close(self) -> None:
-        """Fill to 100 % and stop the progress display."""
+        """Fill to 100% and stop the progress display."""
         if self._task_id is not None:
             if self.total:
                 self._progress.update(self._task_id, completed=self.total)
@@ -70,14 +79,14 @@ def _fetch(pup: po.Pooch, fname: str) -> str:
 
     Parameters
     ----------
-    pup : :class:`pooch.Pooch`
+    pup : pooch.Pooch
         The Pooch instance managing the registry.
-    fname : :class:`str`
-        The file name to fetch (must be registered in *pup*).
+    fname : str
+        The file name to fetch (must be registered in pup).
 
     Returns
     -------
-    full_path : :class:`str`
+    full_path : str
         The absolute path to the fetched file on disk.
 
     """
@@ -85,19 +94,19 @@ def _fetch(pup: po.Pooch, fname: str) -> str:
     return pup.fetch(fname, progressbar=RichProgressBar(fname, preset_total=preset_total))
 
 
-def _pooch_from_doi(doi, path=CACHE_DIR):
+def _pooch_from_doi(doi: str, path: str = CACHE_DIR) -> po.Pooch:
     """Create a Pooch instance from a DOI.
 
     Parameters
     ----------
-    doi : :class:`str`
+    doi : str
         The DOI of the archive.
-    path : :class:`str`
-        Path to the directory where the data should be stored.
+    path : str, optional
+        Path to the directory where the data should be stored. Default is CACHE_DIR.
 
     Returns
     -------
-    pup : :class:`pooch.Pooch`
+    pup : pooch.Pooch
         The Pooch instance.
 
     """

--- a/src/irdl/ista.py
+++ b/src/irdl/ista.py
@@ -23,6 +23,25 @@ class IstaBaseDataset(BaseDataset):
     the same ingestion logic to convert HDF5 to SOFA format.
     """
 
+    def _source_filename(self, **kwargs) -> str:
+        """Construct the raw input filename with extension.
+
+        Shared implementation for MIRACLE and SRIRACHA datasets.
+
+        Parameters
+        ----------
+        **kwargs : :class:`dict`
+            Must contain 'scenario'. May contain 'dataset_split'.
+
+        Returns
+        -------
+        :class:`str`
+            Filename in format "{scenario}[-{split}].h5".
+        """
+        scenario = kwargs["scenario"]
+        split = kwargs.get("dataset_split")
+        return f"{scenario}{('-' + split) if split else ''}.h5"
+
     def ingest(self, file_path: Path) -> Any:
         """Convert a MIRACLE/SRIRACHA HDF5 file into a SOFA object.
 
@@ -135,35 +154,6 @@ class MiracleDataset(IstaBaseDataset):
             output_format=output_format,
         )
 
-    def _output_path(self, output_format, cache_dir, export_dir, **kwargs):
-        """Construct the output path for a MIRACLE file-based output.
-
-        Parameters
-        ----------
-        output_format : str
-            One of 'sofa', 'hdf5', 'raw'. Other formats return None.
-        cache_dir : Path
-            Cache directory.
-        export_dir : Path or None
-            Optional export directory; takes priority over cache_dir.
-        **kwargs
-            Must contain 'scenario'. May contain 'dataset_split'.
-
-        Returns
-        -------
-        Path or None
-            Canonical output path under '<base>/MIRACLE/', or None for
-            in-memory formats.
-        """
-        if output_format not in ("sofa", "hdf5", "raw"):
-            return None
-        ext = ".sofa" if output_format == "sofa" else ".h5"
-        scenario = kwargs["scenario"]
-        split = kwargs.get("dataset_split")
-        name = f"{scenario}{('-' + split) if split else ''}{ext}"
-        base = (export_dir if export_dir is not None else cache_dir) / "MIRACLE"
-        return base / name
-
     def validate_params(self, **dataset_kwargs) -> None:
         """Validate MIRACLE-specific parameters.
 
@@ -214,33 +204,29 @@ class MiracleDataset(IstaBaseDataset):
         Path
             Path to the final HDF5 file, ready for ingest().
         """
-        cache_dir = cache_dir / "MIRACLE"
-        export_dir = export_dir / "MIRACLE" if export_dir is not None else None
-        target_dir = export_dir if export_dir is not None else cache_dir
         scenario = kwargs["scenario"]
         split = kwargs.get("dataset_split")
 
-        # 1. Final file already on disk?
-        final_name = f"{scenario}-{split}.h5" if split else f"{scenario}.h5"
-        cached = self._lookup(final_name, cache_dir, export_dir)
-        if cached is not None:
-            return cached
+        # 1. Final file already on disk? Use _input_path for consistent path construction
+        file_path = self._input_path(cache_dir, export_dir, **kwargs)
+        if file_path.exists():
+            return file_path
 
         # 2. Need the full scenario file (reuse if present, else fetch)
-        full_name = f"{scenario}.h5"
-        full_path = self._lookup(full_name, cache_dir, export_dir)
-        if full_path is None:
-            target_dir.mkdir(parents=True, exist_ok=True)
-            pup = _pooch_from_doi(self.doi, path=target_dir)
-            _fetch(pup, full_name)
-            full_path = target_dir / full_name
+        # Construct path for full scenario file (without split)
+        full_kwargs = {**kwargs, "dataset_split": None}
+        full_path = self._input_path(cache_dir, export_dir, **full_kwargs)
+        if not full_path.exists():
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            pup = _pooch_from_doi(self.doi, path=full_path.parent)
+            _fetch(pup, full_path.name)
 
         # 3. No split requested -> the full file is the final file
         if not split:
             return full_path
 
         # 4. Split the full file into the requested quadrant
-        return self._extract_split(full_path, split, target_dir)
+        return self._extract_split(full_path, split, full_path.parent)
 
     def _extract_split(self, file_path: Path, dataset_split: str, cache_dir: Path) -> Path:
         """Extract a dataset split from a full MIRACLE HDF5 file.
@@ -378,34 +364,7 @@ class SrirachaDataset(IstaBaseDataset):
         if output_format == "raw" and scenario and scenario[-1] != "D" and dataset_split is None:
             raise ValueError("raw output_format not supported for non-dense SRIRACHA scenarios without split")
 
-    def _output_path(self, output_format, cache_dir, export_dir, **kwargs):
-        """Construct the output path for a SRIRACHA file-based output.
 
-        Parameters
-        ----------
-        output_format : str
-            One of 'sofa', 'hdf5', 'raw'. Other formats return None.
-        cache_dir : Path
-            Cache directory.
-        export_dir : Path or None
-            Optional export directory; takes priority over cache_dir.
-        **kwargs
-            Must contain 'scenario'. May contain 'dataset_split'.
-
-        Returns
-        -------
-        Path or None
-            Canonical output path under '<base>/SRIRACHA/', or None for
-            in-memory formats.
-        """
-        if output_format not in ("sofa", "hdf5", "raw"):
-            return None
-        ext = ".sofa" if output_format == "sofa" else ".h5"
-        scenario = kwargs["scenario"]
-        split = kwargs.get("dataset_split")
-        name = f"{scenario}{('-' + split) if split else ''}{ext}"
-        base = (export_dir if export_dir is not None else cache_dir) / "SRIRACHA"
-        return base / name
 
     def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
         """Return the path to a SRIRACHA HDF5 file, fetching and merging as needed.
@@ -431,17 +390,17 @@ class SrirachaDataset(IstaBaseDataset):
         Path
             Path to the final HDF5 file, ready for ingest().
         """
-        cache_dir = cache_dir / "SRIRACHA"
-        export_dir = export_dir / "SRIRACHA" if export_dir is not None else None
-        target_dir = export_dir if export_dir is not None else cache_dir
         scenario = kwargs["scenario"]
         split = kwargs.get("dataset_split")
 
-        # 1. Final file already on disk?
-        final_name = f"{scenario}-{split}.h5" if split else f"{scenario}.h5"
-        cached = self._lookup(final_name, cache_dir, export_dir)
-        if cached is not None:
-            return cached
+        # 1. Final file already on disk? Use _input_path for consistent path construction
+        file_path = self._input_path(cache_dir, export_dir, **kwargs)
+        if file_path.exists():
+            return file_path
+
+        # 2. Need to download/merge
+        target_dir = file_path.parent
+        final_name = file_path.name
 
         # 2a. Dense scenario or explicit split -> single-file download
         if scenario.endswith("D") or split is not None:

--- a/src/irdl/ista.py
+++ b/src/irdl/ista.py
@@ -105,32 +105,6 @@ class MiracleDataset(IstaBaseDataset):
     raw_format = "hdf5"
     room_volume = 830 #metadata needed for creation of sofa file
 
-    def validate_params(self, dataset_kwargs: dict) -> None:
-        """Validate MIRACLE-specific parameters.
-
-        Parameters
-        ----------
-        **dataset_kwargs
-            Must contain 'scenario' (one of 'A1', 'A2', 'D1', 'R2'). May
-            contain 'dataset_split' (one of 'C1', 'C2', 'C3', 'C4', or None).
-            Scenario 'D1' cannot be split.
-
-        Raises
-        ------
-        ValueError
-            If scenario or split is out of range, or 'D1' is combined with a
-            split.
-        """
-        scenario = dataset_kwargs["scenario"]
-        dataset_split = dataset_kwargs.get("dataset_split")
-
-        if scenario not in ["A1", "A2", "D1", "R2"]:
-            raise ValueError("scenario must be one of ['A1', 'A2', 'D1', 'R2']")
-        if dataset_split not in [None, "C1", "C2", "C3", "C4"]:
-            raise ValueError("dataset_split must be None or in [C1, C2, C3, C4]")
-        if scenario == "D1" and dataset_split is not None:
-            raise ValueError("scenario D1 cannot be split")
-
     @classmethod
     def get(
         cls,
@@ -154,6 +128,7 @@ class MiracleDataset(IstaBaseDataset):
             export_dir=export_dir,
             output_format=output_format,
         )
+
 
     def _output_path(self, output_format, cache_dir, export_dir, **kwargs):
         """Construct the output path for a MIRACLE file-based output.
@@ -185,6 +160,34 @@ class MiracleDataset(IstaBaseDataset):
         name = f"{scenario}{('-' + split) if split else ''}{ext}"
         base = (export_dir if export_dir is not None else cache_dir) / "MIRACLE"
         return base / name
+    
+
+    def validate_params(self, **dataset_kwargs) -> None:
+        """Validate MIRACLE-specific parameters.
+
+        Parameters
+        ----------
+        **dataset_kwargs
+            Must contain 'scenario' (one of 'A1', 'A2', 'D1', 'R2'). May
+            contain 'dataset_split' (one of 'C1', 'C2', 'C3', 'C4', or None).
+            Scenario 'D1' cannot be split. ``output_format`` is also passed
+            but unused here.
+
+        Raises
+        ------
+        ValueError
+            If scenario or split is out of range, or 'D1' is combined with a
+            split.
+        """
+        scenario = dataset_kwargs["scenario"]
+        dataset_split = dataset_kwargs.get("dataset_split")
+
+        if scenario not in ["A1", "A2", "D1", "R2"]:
+            raise ValueError("scenario must be one of ['A1', 'A2', 'D1', 'R2']")
+        if dataset_split not in [None, "C1", "C2", "C3", "C4"]:
+            raise ValueError("dataset_split must be None or in [C1, C2, C3, C4]")
+        if scenario == "D1" and dataset_split is not None:
+            raise ValueError("scenario D1 cannot be split")
 
 
     def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
@@ -309,37 +312,6 @@ class SrirachaDataset(IstaBaseDataset):
     raw_format = "hdf5"
     room_volume = 73.5
 
-    def validate_params(self, output_format: str ,**dataset_kwargs: dict) -> None:
-        """Validate SRIRACHA-specific parameters.
-
-        Parameters
-        ----------
-        output_format : str
-            Used to forbid 'raw' for non-dense scenarios without a split.
-        **dataset_kwargs
-            Must contain 'scenario' (one of 'SR1', 'SRA1', 'SR1-D', 'SRA1-D',
-            'SR2', 'SRA2', 'SR2-D', 'SRA2-D'). May contain 'dataset_split'
-            (one of 'C1', 'C2', 'C3', 'C4', or None). Dense scenarios
-            (ending in '-D') cannot be split.
-
-        Raises
-        ------
-        ValueError
-            If scenario or split is invalid, a dense scenario is combined with
-            a split, or 'raw' is requested for a non-dense full plane.
-        """
-        scenario = dataset_kwargs.get("scenario")
-        dataset_split = dataset_kwargs.get("dataset_split")
-
-        if scenario not in ["SR1", "SRA1", "SR1-D", "SRA1-D", "SR2", "SRA2", "SR2-D", "SRA2-D"]:
-            raise ValueError("scenario must be one of [SR1, SRA1, SR1-D, SRA1-D, SR2, SRA2, SR2-D, SRA2-D]")
-        if dataset_split not in [None, "C1", "C2", "C3", "C4"]:
-            raise ValueError("dataset_split must be None or in [C1, C2, C3, C4]")
-        if scenario[-1] == "D" and dataset_split is not None:
-            raise ValueError("dense datasets do not have splits")
-        if output_format == "raw" and scenario and scenario[-1] != "D" and dataset_split is None:
-            raise ValueError("raw output_format not supported for non-dense SRIRACHA scenarios without split")
-
     @classmethod
     def get(
         cls,
@@ -365,6 +337,40 @@ class SrirachaDataset(IstaBaseDataset):
             export_dir=export_dir,
             output_format=output_format,
         )
+
+
+    def validate_params(self, **dataset_kwargs) -> None:
+        """Validate SRIRACHA-specific parameters.
+
+        Parameters
+        ----------
+        **dataset_kwargs
+            Must contain 'scenario' (one of 'SR1', 'SRA1', 'SR1-D', 'SRA1-D',
+            'SR2', 'SRA2', 'SR2-D', 'SRA2-D'). May contain 'dataset_split'
+            (one of 'C1', 'C2', 'C3', 'C4', or None). Dense scenarios
+            (ending in '-D') cannot be split. ``output_format`` is also
+            passed and used to forbid 'raw' for non-dense full-plane
+            scenarios.
+
+        Raises
+        ------
+        ValueError
+            If scenario or split is invalid, a dense scenario is combined with
+            a split, or 'raw' is requested for a non-dense full plane.
+        """
+        scenario = dataset_kwargs.get("scenario")
+        dataset_split = dataset_kwargs.get("dataset_split")
+        output_format = dataset_kwargs.get("output_format")
+
+        if scenario not in ["SR1", "SRA1", "SR1-D", "SRA1-D", "SR2", "SRA2", "SR2-D", "SRA2-D"]:
+            raise ValueError("scenario must be one of [SR1, SRA1, SR1-D, SRA1-D, SR2, SRA2, SR2-D, SRA2-D]")
+        if dataset_split not in [None, "C1", "C2", "C3", "C4"]:
+            raise ValueError("dataset_split must be None or in [C1, C2, C3, C4]")
+        if scenario[-1] == "D" and dataset_split is not None:
+            raise ValueError("dense datasets do not have splits")
+        if output_format == "raw" and scenario and scenario[-1] != "D" and dataset_split is None:
+            raise ValueError("raw output_format not supported for non-dense SRIRACHA scenarios without split")
+
 
     def _output_path(self, output_format, cache_dir, export_dir, **kwargs):
         """Construct the output path for a SRIRACHA file-based output.
@@ -443,6 +449,7 @@ class SrirachaDataset(IstaBaseDataset):
 
         # 2b. Non-dense full plane -> download 4 split files and merge
         return self._download_and_merge(scenario, target_dir)
+
 
     def _download_and_merge(self, scenario: str, cache_dir: Path, **kwargs) -> Path:
         """Download four quadrant HDF5 files and merge them into a full-plane file.

--- a/src/irdl/ista.py
+++ b/src/irdl/ista.py
@@ -6,7 +6,6 @@
 """
 
 from pathlib import Path
-from typing import Any
 
 import h5py as h5
 import numpy as np
@@ -21,6 +20,11 @@ class IstaBaseDataset(BaseDataset):
 
     Both MIRACLE and SRIRACHA share identical HDF5 file structure and can use
     the same ingestion logic to convert HDF5 to SOFA format.
+
+    Attributes
+    ----------
+    room_volume : float
+        Room volume in cubic meters, used for SOFA metadata.
     """
 
     def _source_filename(self, **kwargs) -> str:
@@ -30,19 +34,19 @@ class IstaBaseDataset(BaseDataset):
 
         Parameters
         ----------
-        **kwargs : :class:`dict`
+        **kwargs : dict
             Must contain 'scenario'. May contain 'dataset_split'.
 
         Returns
         -------
-        :class:`str`
+        str
             Filename in format "{scenario}[-{split}].h5".
         """
         scenario = kwargs["scenario"]
         split = kwargs.get("dataset_split")
         return f"{scenario}{('-' + split) if split else ''}.h5"
 
-    def ingest(self, file_path: Path) -> Any:
+    def ingest(self, file_path: Path) -> sf.Sofa:
         """Convert a MIRACLE/SRIRACHA HDF5 file into a SOFA object.
 
         Both datasets share an identical HDF5 layout, so this single
@@ -122,7 +126,17 @@ class IstaBaseDataset(BaseDataset):
 
 
 class MiracleDataset(IstaBaseDataset):
-    """MIRACLE: Microphone Array Impulse Response Dataset for Acoustic Learning."""
+    """MIRACLE: Microphone Array Impulse Response Dataset for Acoustic Learning.
+
+    Attributes
+    ----------
+    name : str
+        Dataset name ("miracle").
+    doi : str
+        Digital Object Identifier ("10.14279/depositonce-20837").
+    room_volume : float
+        Room volume in cubic meters (830).
+    """
 
     name = "miracle"
     doi = "10.14279/depositonce-20837"
@@ -137,16 +151,14 @@ class MiracleDataset(IstaBaseDataset):
         export_dir: str | Path | None = None,
         output_format: str = "pyfar",
     ):
-        """Select a scenario and optional quadrant split.
-
+        """
         scenario : str
             Scenario to download. One of 'A1', 'A2', 'D1', 'R2'.
         dataset_split : str or None, optional
             Artificial dataset split. One of 'C1', 'C2', 'C3', 'C4' or None.
             Dense scenarios (D1) cannot be split.
-        """
-        instance = cls()
-        return instance._get(
+        """ # noqa: D205, D403
+        return cls()._get(
             scenario=scenario,
             dataset_split=dataset_split,
             cache_dir=cache_dir,
@@ -159,7 +171,7 @@ class MiracleDataset(IstaBaseDataset):
 
         Parameters
         ----------
-        **dataset_kwargs
+        **dataset_kwargs : dict
             Must contain 'scenario' (one of 'A1', 'A2', 'D1', 'R2'). May
             contain 'dataset_split' (one of 'C1', 'C2', 'C3', 'C4', or None).
             Scenario 'D1' cannot be split. ``output_format`` is also passed
@@ -168,8 +180,7 @@ class MiracleDataset(IstaBaseDataset):
         Raises
         ------
         ValueError
-            If scenario or split is out of range, or 'D1' is combined with a
-            split.
+            If scenario or split is out of range, or 'D1' is combined with a split.
         """
         scenario = dataset_kwargs["scenario"]
         dataset_split = dataset_kwargs.get("dataset_split")
@@ -181,52 +192,64 @@ class MiracleDataset(IstaBaseDataset):
         if scenario == "D1" and dataset_split is not None:
             raise ValueError("scenario D1 cannot be split")
 
-    def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
-        """Return the path to a MIRACLE HDF5 file, fetching and splitting as needed.
+    def download(self, target_path: Path, **kwargs) -> Path:
+        """Download MIRACLE dataset file.
 
-        Flow:
-
-        1. If the final (possibly split) file is already on disk, return it.
-        2. Otherwise download the full scenario file if missing.
-        3. If a split is requested, extract the corresponding quadrant.
+        Downloads the full scenario HDF5 file. If a split is requested,
+        the split will be extracted in _process().
 
         Parameters
         ----------
-        cache_dir : Path
-            Cache directory.
-        export_dir : Path or None
-            Optional export directory; takes priority over cache_dir for writes.
-        **kwargs
-            Must contain 'scenario'. May contain 'dataset_split'.
+        target_path : Path
+            Target path where the file should be downloaded.
+        **kwargs : dict
+            Must contain 'scenario'. May contain 'dataset_split', 'cache_dir', 'export_dir'.
 
         Returns
         -------
         Path
-            Path to the final HDF5 file, ready for ingest().
+            Path to the downloaded full scenario HDF5 file.
         """
-        scenario = kwargs["scenario"]
-        split = kwargs.get("dataset_split")
-
-        # 1. Final file already on disk? Use _input_path for consistent path construction
-        file_path = self._input_path(cache_dir, export_dir, **kwargs)
-        if file_path.exists():
-            return file_path
-
-        # 2. Need the full scenario file (reuse if present, else fetch)
-        # Construct path for full scenario file (without split)
+        # Download the full scenario file (without split)
         full_kwargs = {**kwargs, "dataset_split": None}
-        full_path = self._input_path(cache_dir, export_dir, **full_kwargs)
+        full_path = target_path.parent / self._source_filename(**full_kwargs)
+
         if not full_path.exists():
             full_path.parent.mkdir(parents=True, exist_ok=True)
             pup = _pooch_from_doi(self.doi, path=full_path.parent)
             _fetch(pup, full_path.name)
 
-        # 3. No split requested -> the full file is the final file
-        if not split:
-            return full_path
+        return full_path
 
-        # 4. Split the full file into the requested quadrant
-        return self._extract_split(full_path, split, full_path.parent)
+    def _process(self, file_path: Path, **kwargs) -> Path:
+        """Post-process MIRACLE file if needed.
+
+        If a dataset_split is requested and the file is the full scenario file,
+        extracts the corresponding quadrant split.
+
+        Parameters
+        ----------
+        file_path : Path
+            Path to the HDF5 file (may be full scenario or already split).
+        **kwargs : dict
+            Must contain 'scenario'. May contain 'dataset_split'.
+
+        Returns
+        -------
+        Path
+            Path to the processed file (split file if extraction was needed).
+        """
+        split = kwargs.get("dataset_split")
+
+        # If no split requested, return file as-is
+        if not split:
+            return file_path
+
+        # Extract the requested split from the full file
+        cache_dir = kwargs.get("cache_dir")
+        export_dir = kwargs.get("export_dir")
+        target_dir = (Path(export_dir) if export_dir else Path(cache_dir)) / self.name.upper()
+        return self._extract_split(file_path, split, target_dir)
 
     def _extract_split(self, file_path: Path, dataset_split: str, cache_dir: Path) -> Path:
         """Extract a dataset split from a full MIRACLE HDF5 file.
@@ -298,7 +321,17 @@ class MiracleDataset(IstaBaseDataset):
 
 
 class SrirachaDataset(IstaBaseDataset):
-    """SRIRACHA: Shoebox Room Impulse Response Archive with Varying Absorption."""
+    """SRIRACHA: Shoebox Room Impulse Response Archive with Varying Absorption.
+
+    Attributes
+    ----------
+    name : str
+        Dataset name ("sriracha").
+    doi : str
+        Digital Object Identifier ("10.14279/depositonce-23943").
+    room_volume : float
+        Room volume in cubic meters (73.5).
+    """
 
     name = "sriracha"
     doi = "10.14279/depositonce-23943"
@@ -313,18 +346,16 @@ class SrirachaDataset(IstaBaseDataset):
         export_dir: str | Path | None = None,
         output_format: str = "pyfar",
     ):
-        """Select a scenario and optional quadrant split.
-
-        scenario : str
+        """
+        scenario : str, optional
             Scenario to download. One of 'SR1', 'SRA1', 'SR1-D', 'SRA1-D',
-            'SR2', 'SRA2', 'SR2-D', 'SRA2-D'.
+            'SR2', 'SRA2', 'SR2-D', 'SRA2-D'. Default is 'SR1-D'.
         dataset_split : str or None, optional
             Optional dataset split for full-plane scenarios. One of 'C1',
             'C2', 'C3', 'C4' or None. Dense scenarios (ending in '-D') do not
-            have splits.
-        """
-        instance = cls()
-        return instance._get(
+            have splits. Default is None.
+        """  # noqa: D205, D403
+        return cls()._get(
             scenario=scenario,
             dataset_split=dataset_split,
             cache_dir=cache_dir,
@@ -337,7 +368,7 @@ class SrirachaDataset(IstaBaseDataset):
 
         Parameters
         ----------
-        **dataset_kwargs
+        **dataset_kwargs : dict
             Must contain 'scenario' (one of 'SR1', 'SRA1', 'SR1-D', 'SRA1-D',
             'SR2', 'SRA2', 'SR2-D', 'SRA2-D'). May contain 'dataset_split'
             (one of 'C1', 'C2', 'C3', 'C4', or None). Dense scenarios
@@ -364,53 +395,98 @@ class SrirachaDataset(IstaBaseDataset):
         if output_format == "raw" and scenario and scenario[-1] != "D" and dataset_split is None:
             raise ValueError("raw output_format not supported for non-dense SRIRACHA scenarios without split")
 
+    def download(self, target_path: Path, **kwargs) -> Path:
+        """Download SRIRACHA dataset file(s).
 
-
-    def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
-        """Return the path to a SRIRACHA HDF5 file, fetching and merging as needed.
-
-        Flow:
-
-        1. If the final file is already on disk, return it.
-        2. For dense scenarios or explicit splits, download a single file.
-        3. For non-dense full-plane scenarios, download the four quadrant
-           files and merge them into one.
+        For dense scenarios or explicit splits, downloads a single file.
+        For non-dense full-plane scenarios, downloads all 4 split files
+        and returns the path to one of them (merging happens in _process).
 
         Parameters
         ----------
-        cache_dir : Path
-            Cache directory.
-        export_dir : Path or None
-            Optional export directory; takes priority over cache_dir for writes.
-        **kwargs
-            Must contain 'scenario'. May contain 'dataset_split'.
+        target_path : Path
+            Target path where the file should be downloaded.
+        **kwargs : dict
+            Must contain 'scenario'. May contain 'dataset_split', 'cache_dir', 'export_dir'.
 
         Returns
         -------
         Path
-            Path to the final HDF5 file, ready for ingest().
+            Path to the downloaded file (or one of the split files for non-dense).
         """
+        target_dir = target_path.parent
+        final_name = target_path.name
         scenario = kwargs["scenario"]
         split = kwargs.get("dataset_split")
 
-        # 1. Final file already on disk? Use _input_path for consistent path construction
-        file_path = self._input_path(cache_dir, export_dir, **kwargs)
-        if file_path.exists():
-            return file_path
-
-        # 2. Need to download/merge
-        target_dir = file_path.parent
-        final_name = file_path.name
-
-        # 2a. Dense scenario or explicit split -> single-file download
+        # Dense scenario or explicit split -> single-file download
         if scenario.endswith("D") or split is not None:
             target_dir.mkdir(parents=True, exist_ok=True)
             pup = _pooch_from_doi(self.doi, path=target_dir)
             _fetch(pup, final_name)
             return target_dir / final_name
 
-        # 2b. Non-dense full plane -> download 4 split files and merge
+        # Non-dense full plane -> download 4 split files
+        # We'll return the path to the first split file; _process will merge all 4
+        return self._download_split_files(scenario, target_dir)
+
+    def _process(self, file_path: Path, **kwargs) -> Path:
+        """Post-process SRIRACHA file if needed.
+
+        For non-dense full-plane scenarios, merges the 4 downloaded split files
+        into a single file.
+
+        Parameters
+        ----------
+        file_path : Path
+            Path to one of the downloaded files.
+        **kwargs : dict
+            Must contain 'scenario'. May contain 'dataset_split', 'cache_dir', 'export_dir'.
+
+        Returns
+        -------
+        Path
+            Path to the processed file (merged file for non-dense, same file otherwise).
+        """
+        scenario = kwargs["scenario"]
+        split = kwargs.get("dataset_split")
+        cache_dir = kwargs.get("cache_dir")
+        export_dir = kwargs.get("export_dir")
+
+        # Dense scenarios and explicit splits don't need merging
+        if scenario.endswith("D") or split is not None:
+            return file_path
+
+        # Non-dense full plane -> merge all 4 split files
+        target_dir = (Path(export_dir) if export_dir else Path(cache_dir)) / self.name.upper()
         return self._download_and_merge(scenario, target_dir)
+
+    def _download_split_files(self, scenario: str, cache_dir: Path) -> Path:
+        """Download the 4 split files for a non-dense SRIRACHA scenario.
+
+        Parameters
+        ----------
+        scenario : str
+            Scenario name (e.g. 'SR1').
+        cache_dir : Path
+            Directory where split files are downloaded.
+
+        Returns
+        -------
+        Path
+            Path to the first split file (C1).
+        """
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        offsets = {"C1": (0, 0), "C2": (0, 1), "C3": (1, 0), "C4": (1, 1)}
+
+        split_files = {}
+        pup = _pooch_from_doi(self.doi, path=cache_dir)
+        for split_name in offsets:
+            fname = f"{scenario}-{split_name}.h5"
+            _fetch(pup, fname)
+            split_files[split_name] = cache_dir / fname
+
+        return split_files["C1"]
 
     def _download_and_merge(self, scenario: str, cache_dir: Path) -> Path:
         """Download four quadrant HDF5 files and merge them into a full-plane file.

--- a/src/irdl/ista.py
+++ b/src/irdl/ista.py
@@ -55,12 +55,12 @@ class IstaBaseDataset(BaseDataset):
 
         Parameters
         ----------
-        file_path : Path
+        file_path : :class:`pathlib.Path`
             Path to the HDF5 file.
 
         Returns
         -------
-        sofar.Sofa
+        :class:`sofar.Sofa`
             SOFA object in the SingleRoomMIMOSRIR convention.
         """
         with h5.File(file_path, "r") as f:
@@ -157,7 +157,7 @@ class MiracleDataset(IstaBaseDataset):
         dataset_split : str or None, optional
             Artificial dataset split. One of 'C1', 'C2', 'C3', 'C4' or None.
             Dense scenarios (D1) cannot be split.
-        """ # noqa: D205, D403
+        """  # noqa: D205, D403
         return cls()._get(
             scenario=scenario,
             dataset_split=dataset_split,
@@ -200,14 +200,14 @@ class MiracleDataset(IstaBaseDataset):
 
         Parameters
         ----------
-        target_path : Path
+        target_path : :class:`pathlib.Path`
             Target path where the file should be downloaded.
         **kwargs : dict
             Must contain 'scenario'. May contain 'dataset_split', 'cache_dir', 'export_dir'.
 
         Returns
         -------
-        Path
+        :class:`pathlib.Path`
             Path to the downloaded full scenario HDF5 file.
         """
         # Download the full scenario file (without split)
@@ -229,14 +229,14 @@ class MiracleDataset(IstaBaseDataset):
 
         Parameters
         ----------
-        file_path : Path
+        file_path : :class:`pathlib.Path`
             Path to the HDF5 file (may be full scenario or already split).
         **kwargs : dict
             Must contain 'scenario'. May contain 'dataset_split'.
 
         Returns
         -------
-        Path
+        :class:`pathlib.Path`
             Path to the processed file (split file if extraction was needed).
         """
         split = kwargs.get("dataset_split")
@@ -259,16 +259,16 @@ class MiracleDataset(IstaBaseDataset):
 
         Parameters
         ----------
-        file_path : Path
+        file_path : :class:`pathlib.Path`
             Path to the full HDF5 file.
         dataset_split : str
             Split to extract. One of 'C1', 'C2', 'C3', 'C4'.
-        cache_dir : Path
+        cache_dir : :class:`pathlib.Path`
             Directory where the extracted file is written.
 
         Returns
         -------
-        Path
+        :class:`pathlib.Path`
             Path to the extracted split HDF5 file.
         """
         cache_dir.mkdir(parents=True, exist_ok=True)
@@ -404,14 +404,14 @@ class SrirachaDataset(IstaBaseDataset):
 
         Parameters
         ----------
-        target_path : Path
+        target_path : :class:`pathlib.Path`
             Target path where the file should be downloaded.
         **kwargs : dict
             Must contain 'scenario'. May contain 'dataset_split', 'cache_dir', 'export_dir'.
 
         Returns
         -------
-        Path
+        :class:`pathlib.Path`
             Path to the downloaded file (or one of the split files for non-dense).
         """
         target_dir = target_path.parent

--- a/src/irdl/ista.py
+++ b/src/irdl/ista.py
@@ -126,7 +126,7 @@ class IstaBaseDataset(BaseDataset):
 
 
 class MiracleDataset(IstaBaseDataset):
-    """MIRACLE: Microphone Array Impulse Response Dataset for Acoustic Learning.
+    """Download and extract the MIRACLE database from DepositOnce.
 
     Attributes
     ----------
@@ -321,7 +321,7 @@ class MiracleDataset(IstaBaseDataset):
 
 
 class SrirachaDataset(IstaBaseDataset):
-    """SRIRACHA: Shoebox Room Impulse Response Archive with Varying Absorption.
+    """Download and extract the SRIRACHA database from DepositOnce.
 
     Attributes
     ----------

--- a/src/irdl/ista.py
+++ b/src/irdl/ista.py
@@ -107,7 +107,6 @@ class MiracleDataset(IstaBaseDataset):
 
     name = "miracle"
     doi = "10.14279/depositonce-20837"
-    raw_format = "hdf5"
     room_volume = 830  # metadata needed for creation of sofa file
 
     @classmethod
@@ -158,8 +157,6 @@ class MiracleDataset(IstaBaseDataset):
         """
         if output_format not in ("sofa", "hdf5", "raw"):
             return None
-        if output_format == "raw":
-            output_format = self.raw_format
         ext = ".sofa" if output_format == "sofa" else ".h5"
         scenario = kwargs["scenario"]
         split = kwargs.get("dataset_split")
@@ -319,7 +316,6 @@ class SrirachaDataset(IstaBaseDataset):
 
     name = "sriracha"
     doi = "10.14279/depositonce-23943"
-    raw_format = "hdf5"
     room_volume = 73.5
 
     @classmethod
@@ -404,8 +400,6 @@ class SrirachaDataset(IstaBaseDataset):
         """
         if output_format not in ("sofa", "hdf5", "raw"):
             return None
-        if output_format == "raw":
-            output_format = self.raw_format
         ext = ".sofa" if output_format == "sofa" else ".h5"
         scenario = kwargs["scenario"]
         split = kwargs.get("dataset_split")

--- a/src/irdl/ista.py
+++ b/src/irdl/ista.py
@@ -5,13 +5,12 @@
 
 """
 
-from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
 import h5py as h5
 import numpy as np
-import sofar as sf
+import sofar as sf 
 
 from irdl.base import BaseDataset
 from irdl.downloader import CACHE_DIR, _fetch, _pooch_from_doi
@@ -24,10 +23,7 @@ class IstaBaseDataset(BaseDataset):
     the same ingestion logic to convert HDF5 to SOFA format.
     """
 
-    # Room volume for SOFA metadata (subclasses must define)
-    room_volume: float
-
-    def ingest(self, file_path: Path) -> sf.Sofa:
+    def ingest(self, file_path: Path) -> Any:
         """Convert a MIRACLE/SRIRACHA HDF5 file into a SOFA object.
 
         Both datasets share an identical HDF5 layout, so this single
@@ -45,15 +41,15 @@ class IstaBaseDataset(BaseDataset):
             SOFA object in the SingleRoomMIMOSRIR convention.
         """
         with h5.File(file_path, "r") as f:
-            ir = f["data"]["impulse_response"][()]
-            receiver_pos = f["data"]["location"]["receiver"][()]
-            source_pos = f["data"]["location"]["source"][()]
+            ir = f["data"]["impulse_response"][()]              
+            receiver_pos = f["data"]["location"]["receiver"][()]  
+            source_pos = f["data"]["location"]["source"][()]     
             sampling_rate = f["metadata"]["sampling_rate"][()]
             temperature = f["metadata"]["temperature"][()]
 
-        # SOFA dimension naming
-        M, R, N = ir.shape  # number of measurements, receiver and samples
-        E = 1  # number of emitters
+        # SOFA dimension naming 
+        M, R, N = ir.shape # number of measurements, receiver and samples
+        E = 1 # number of emitters
         C = 3  # number of coordinates
         I = 1  # unity dimensions
 
@@ -61,46 +57,41 @@ class IstaBaseDataset(BaseDataset):
 
         # --- metadata  -------------------------------------------------
         sofa.GLOBAL_Title = self.name.upper()
-        sofa.GLOBAL_AuthorContact = "a.pelling@tu-berlin.de; adam.kujawski@tu-berlin.de"
+        sofa.GLOBAL_AuthorContact = "a.pelling@tu-berlin.de; adam.kujawksi@tu-berlin.de"
         sofa.GLOBAL_Organization = "TU Berlin, Department of Engineering Acoustics"
         sofa.GLOBAL_License = "CC BY-NC-SA 4.0"
         sofa.GLOBAL_References = self.doi
         sofa.GLOBAL_DatabaseName = self.name.upper()
         sofa.GLOBAL_RoomLocation = "TU Berlin, Einsteinufer 25"
         sofa.GLOBAL_ListenerShortName = "Custom planar microphone array"
-        sofa.GLOBAL_ListenerDescription = (
-            "64-channel planar microphone array "
-            "(1.5 m × 1.5 m aluminium plate, Vogel's spiral, max spacing 1.47 m, 51.2 kHz sampling rate)"
-        )
+        sofa.GLOBAL_ListenerDescription = "64-channel planar microphone array (1.5 m × 1.5 m aluminium plate, Vogel's spiral, max spacing 1.47 m, 51.2 kHz sampling rate)"
         sofa.GLOBAL_ReceiverShortName = "GRAS 40PL-1 Short CCP"
         sofa.GLOBAL_SourceShortName = "Loudspeaker"
-        sofa.GLOBAL_SourceDescription = (
-            "Dynamic 2\" cone loudspeaker in a cylindrical enclosure (Frequency range 100 Hz–16 kHz)"
-        )
-
-        sofa.RoomVolume = self.room_volume  # Dim. 1, M => so add a dimension upfront
-
+        sofa.GLOBAL_SourceDescription = "Dynamic 2” cone loudspeaker in a cylindrical enclosure (Frequency range 100 Hz–16 kHz)"
+    
+        sofa.RoomVolume = self.room_volume # #Dim. 1, M => so add a dimension upfront
+        
         # --- environmental, per-measurement ------------------------------------
-        sofa.RoomTemperature = temperature[..., np.newaxis]  # dim spec is (I, M)
+        sofa.RoomTemperature = temperature[..., np.newaxis] #dim spec is (I, M)
         sofa.RoomTemperature_Units = "celsius"
-
+        
         # --- geometry ----------------------------------------------------------
         # Receiver: fixed microphone array
-        sofa.ReceiverPosition = receiver_pos.reshape(R, C, I)
+        sofa.ReceiverPosition = receiver_pos.reshape(R, C, I) 
         sofa.ReceiverPosition_Type = "cartesian"
         sofa.ReceiverPosition_Units = "metre"
 
         # Source: one cartesian position per measurement
-        sofa.SourcePosition = source_pos  # dim spec is (M, C)
+        sofa.SourcePosition = source_pos ##dim spec is (M, C)
 
         # Emitter: single point source, co-located with the source frame origin
-        sofa.EmitterPosition = np.zeros((E, C, I))
+        sofa.EmitterPosition = np.zeros((E, C, I)) 
         sofa.EmitterPosition_Type = "cartesian"
         sofa.EmitterPosition_Units = "metre"
-
+     
         # --- IR data -----------------------------------------------------------
-        sofa.Data_IR = ir[..., np.newaxis]  # dim spec (M, R, N, E)
-        sofa.Data_SamplingRate = np.full((I, M), sampling_rate)  # dim spec (I, M)
+        sofa.Data_IR = ir[..., np.newaxis] #dim spec (M, R, N, E)
+        sofa.Data_SamplingRate = np.full((I,M), sampling_rate) #dim spec (I, M)
         sofa.Data_Delay = np.zeros((M, R, I))
 
         return sofa
@@ -111,20 +102,24 @@ class MiracleDataset(IstaBaseDataset):
 
     name = "miracle"
     doi = "10.14279/depositonce-20837"
-    room_volume = 830  # metadata needed for creation of sofa file
+    raw_format = "hdf5"
+    room_volume = 830 #metadata needed for creation of sofa file
 
-    def validate_params(self, **dataset_kwargs) -> None:
+    def validate_params(self, dataset_kwargs: dict) -> None:
         """Validate MIRACLE-specific parameters.
 
         Parameters
         ----------
         **dataset_kwargs
-            Dataset-specific parameters to validate. Expected keys: scenario, dataset_split.
+            Must contain 'scenario' (one of 'A1', 'A2', 'D1', 'R2'). May
+            contain 'dataset_split' (one of 'C1', 'C2', 'C3', 'C4', or None).
+            Scenario 'D1' cannot be split.
 
         Raises
         ------
         ValueError
-            If scenario or split is out of range, or 'D1' is combined with a split.
+            If scenario or split is out of range, or 'D1' is combined with a
+            split.
         """
         scenario = dataset_kwargs["scenario"]
         dataset_split = dataset_kwargs.get("dataset_split")
@@ -140,30 +135,17 @@ class MiracleDataset(IstaBaseDataset):
     def get(
         cls,
         scenario: str = "A1",
-        dataset_split: str | None = None,
-        cache_dir: str | Path = CACHE_DIR,
-        export_dir: str | Path | None = None,
+        dataset_split: str = None,
+        cache_dir: str = CACHE_DIR,
+        export_dir: str = None,
         output_format: str = "pyfar",
     ):
-        """Download MIRACLE dataset.
-
-DOI: 10.14279/depositonce-20837
-
-Parameters
-----------
-cache_dir : str
-    Cache directory for downloads. Default: user cache directory.
-export_dir : str, optional
-    Directory for final output. Default: None (stays in cache_dir).
-output_format : str
-    Output format: 'pyfar', 'numpy', 'hdf5', 'sofa', or 'raw'.
-
-scenario : str
-    Scenario to download. One of 'A1', 'A2', 'D1', 'R2'.
-dataset_split : str or None, optional
-    Artificial dataset split. One of 'C1', 'C2', 'C3', 'C4' or None.
-    Dense scenarios (D1) cannot be split.
-"""
+        """scenario : str
+            Scenario to download. One of 'A1', 'A2', 'D1', 'R2'.
+        dataset_split : str or None, optional
+            Artificial dataset split. One of 'C1', 'C2', 'C3', 'C4' or None.
+            Dense scenarios (D1) cannot be split.
+        """
         instance = cls()
         return instance._get(
             scenario=scenario,
@@ -173,7 +155,7 @@ dataset_split : str or None, optional
             output_format=output_format,
         )
 
-    def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
+    def _output_path(self, output_format, cache_dir, export_dir, **kwargs):
         """Construct the output path for a MIRACLE file-based output.
 
         Parameters
@@ -190,10 +172,13 @@ dataset_split : str or None, optional
         Returns
         -------
         Path or None
-            Canonical output path under '<base>/MIRACLE/', or None for in-memory formats.
+            Canonical output path under '<base>/MIRACLE/', or None for
+            in-memory formats.
         """
         if output_format not in ("sofa", "hdf5", "raw"):
             return None
+        if output_format == "raw":
+            output_format = self.raw_format
         ext = ".sofa" if output_format == "sofa" else ".h5"
         scenario = kwargs["scenario"]
         split = kwargs.get("dataset_split")
@@ -201,77 +186,72 @@ dataset_split : str or None, optional
         base = (export_dir if export_dir is not None else cache_dir) / "MIRACLE"
         return base / name
 
-    def _construct_file_name(self, **kwargs) -> str:
-        """Construct HDF5 file name for MIRACLE (always full file, splits extracted later)."""
-        scenario = kwargs["scenario"]
-        # Always download the full file; splits are extracted in _get_file()
-        return f"{scenario}.h5"
-
-    def download(self, **kwargs) -> Path:
-        """Download MIRACLE HDF5 file (always full scenario file).
-
-        Parameters
-        ----------
-        **kwargs
-            Dataset-specific parameters. Must contain 'cache_dir'.
-
-        Returns
-        -------
-        Path
-            Path to the downloaded file.
-        """
-        cache_dir = Path(kwargs["cache_dir"]) / "MIRACLE"
-        cache_dir.mkdir(parents=True, exist_ok=True)
-
-        file_name = self._construct_file_name(**kwargs)
-        file_path = cache_dir / file_name
-
-        # Download if not exists
-        if not file_path.exists():
-            pup = _pooch_from_doi(self.doi, path=cache_dir)
-            _fetch(pup, file_name)
-
-        return file_path
 
     def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
-        """Check cache or download full file, then split if needed.
+        """Return the path to a MIRACLE HDF5 file, fetching and splitting as needed.
+
+        Flow:
+
+        1. If the final (possibly split) file is already on disk, return it.
+        2. Otherwise download the full scenario file if missing.
+        3. If a split is requested, extract the corresponding quadrant.
 
         Parameters
         ----------
         cache_dir : Path
-            Base cache directory.
+            Cache directory.
         export_dir : Path or None
-            Optional export directory.
+            Optional export directory; takes priority over cache_dir for writes.
         **kwargs
-            Dataset-specific parameters. Must contain 'scenario'. May contain 'dataset_split'.
+            Must contain 'scenario'. May contain 'dataset_split'.
 
         Returns
         -------
         Path
-            Path to the file ready for ingest().
+            Path to the final HDF5 file, ready for ingest().
         """
-        dataset_split = kwargs.get("dataset_split")
+        cache_dir = cache_dir / "MIRACLE"
+        export_dir = export_dir / "MIRACLE" if export_dir is not None else None
+        target_dir = export_dir if export_dir is not None else cache_dir
+        scenario = kwargs["scenario"]
+        split = kwargs.get("dataset_split")
 
-        # Download/get the full file using parent's _get_file
-        file_path = super()._get_file(cache_dir, export_dir, **kwargs)
+        # 1. Final file already on disk?
+        final_name = f"{scenario}-{split}.h5" if split else f"{scenario}.h5"
+        cached = self._lookup(final_name, cache_dir, export_dir)
+        if cached is not None:
+            return cached
 
-        # If a split is requested, extract it from the full file
-        if dataset_split is not None:
-            return self._extract_split(file_path, dataset_split, export_dir)
+        # 2. Need the full scenario file (reuse if present, else fetch)
+        full_name = f"{scenario}.h5"
+        full_path = self._lookup(full_name, cache_dir, export_dir)
+        if full_path is None:
+            target_dir.mkdir(parents=True, exist_ok=True)
+            pup = _pooch_from_doi(self.doi, path=target_dir)
+            _fetch(pup, full_name)
+            full_path = target_dir / full_name
 
-        return file_path
+        # 3. No split requested -> the full file is the final file
+        if not split:
+            return full_path
 
-    def _extract_split(self, file_path: Path, dataset_split: str, export_dir: Path | None) -> Path:
+        # 4. Split the full file into the requested quadrant
+        return self._extract_split(full_path, split, target_dir)
+
+    def _extract_split(self, file_path: Path, dataset_split: str, cache_dir: Path) -> Path:
         """Extract a dataset split from a full MIRACLE HDF5 file.
+
+        Reads the full file, indexes the requested quadrant of the source
+        grid, and writes the result to a new HDF5 file.
 
         Parameters
         ----------
         file_path : Path
             Path to the full HDF5 file.
         dataset_split : str
-            Split to extract (C1, C2, C3, C4).
-        export_dir : Path or None
-            Optional directory for the extracted file.
+            Split to extract. One of 'C1', 'C2', 'C3', 'C4'.
+        cache_dir : Path
+            Directory where the extracted file is written.
 
         Returns
         -------
@@ -302,12 +282,8 @@ dataset_split : str or None, optional
         )
 
         # Save split data to a new HDF5 file
-        split_file_name = f"{file_path.stem}-{dataset_split}{file_path.suffix}"
-        if export_dir:
-            split_path = Path(export_dir) / "MIRACLE" / split_file_name
-        else:
-            split_path = file_path.parent / split_file_name
-        split_path.parent.mkdir(parents=True, exist_ok=True)
+        split_file_name = file_path.stem + f"-{dataset_split}{file_path.suffix}"
+        split_path = Path(cache_dir) / split_file_name
 
         with h5.File(split_path, "w") as f:
             data_group = f.create_group("data")
@@ -330,22 +306,28 @@ class SrirachaDataset(IstaBaseDataset):
 
     name = "sriracha"
     doi = "10.14279/depositonce-23943"
+    raw_format = "hdf5"
     room_volume = 73.5
 
-    def validate_params(self, **dataset_kwargs) -> None:
+    def validate_params(self, output_format: str ,**dataset_kwargs: dict) -> None:
         """Validate SRIRACHA-specific parameters.
 
         Parameters
         ----------
+        output_format : str
+            Used to forbid 'raw' for non-dense scenarios without a split.
         **dataset_kwargs
-            Dataset-specific parameters to validate. Expected keys: scenario, dataset_split.
+            Must contain 'scenario' (one of 'SR1', 'SRA1', 'SR1-D', 'SRA1-D',
+            'SR2', 'SRA2', 'SR2-D', 'SRA2-D'). May contain 'dataset_split'
+            (one of 'C1', 'C2', 'C3', 'C4', or None). Dense scenarios
+            (ending in '-D') cannot be split.
 
         Raises
         ------
         ValueError
-            If scenario, split, or output_format combination is invalid.
+            If scenario or split is invalid, a dense scenario is combined with
+            a split, or 'raw' is requested for a non-dense full plane.
         """
-        output_format = dataset_kwargs.get("output_format")
         scenario = dataset_kwargs.get("scenario")
         dataset_split = dataset_kwargs.get("dataset_split")
 
@@ -353,40 +335,28 @@ class SrirachaDataset(IstaBaseDataset):
             raise ValueError("scenario must be one of [SR1, SRA1, SR1-D, SRA1-D, SR2, SRA2, SR2-D, SRA2-D]")
         if dataset_split not in [None, "C1", "C2", "C3", "C4"]:
             raise ValueError("dataset_split must be None or in [C1, C2, C3, C4]")
-        if scenario.endswith("-D") and dataset_split is not None:
+        if scenario[-1] == "D" and dataset_split is not None:
             raise ValueError("dense datasets do not have splits")
-        if output_format == "raw" and scenario and not scenario.endswith("-D") and dataset_split is None:
+        if output_format == "raw" and scenario and scenario[-1] != "D" and dataset_split is None:
             raise ValueError("raw output_format not supported for non-dense SRIRACHA scenarios without split")
 
     @classmethod
     def get(
         cls,
         scenario: str = "SR1-D",
-        dataset_split: str | None = None,
-        cache_dir: str | Path = CACHE_DIR,
-        export_dir: str | Path | None = None,
+        dataset_split: str = None,
+        cache_dir: str = CACHE_DIR,
+        export_dir: str = None,
         output_format: str = "pyfar",
     ):
-        """Download SRIRACHA dataset.
-
-DOI: 10.14279/depositonce-23943
-
-Parameters
-----------
-cache_dir : str
-    Cache directory for downloads. Default: user cache directory.
-export_dir : str, optional
-    Directory for final output. Default: None (stays in cache_dir).
-output_format : str
-    Output format: 'pyfar', 'numpy', 'hdf5', 'sofa', or 'raw'.
-
-scenario : str
-    Scenario to download. One of 'SR1', 'SRA1', 'SR1-D', 'SRA1-D', 'SR2',
-    'SRA2', 'SR2-D', or 'SRA2-D'.
-dataset_split : str or None, optional
-    Optional dataset split for full-plane scenarios. One of 'C1', 'C2',
-    'C3', 'C4', or None. Dense scenarios (ending in -D) do not have splits.
-"""
+        """scenario : str
+            Scenario to download. One of 'SR1', 'SRA1', 'SR1-D', 'SRA1-D',
+            'SR2', 'SRA2', 'SR2-D', 'SRA2-D'.
+        dataset_split : str or None, optional
+            Optional dataset split for full-plane scenarios. One of 'C1',
+            'C2', 'C3', 'C4' or None. Dense scenarios (ending in '-D') do not
+            have splits.
+        """
         instance = cls()
         return instance._get(
             scenario=scenario,
@@ -396,7 +366,7 @@ dataset_split : str or None, optional
             output_format=output_format,
         )
 
-    def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
+    def _output_path(self, output_format, cache_dir, export_dir, **kwargs):
         """Construct the output path for a SRIRACHA file-based output.
 
         Parameters
@@ -413,10 +383,13 @@ dataset_split : str or None, optional
         Returns
         -------
         Path or None
-            Canonical output path under '<base>/SRIRACHA/', or None for in-memory formats.
+            Canonical output path under '<base>/SRIRACHA/', or None for
+            in-memory formats.
         """
         if output_format not in ("sofa", "hdf5", "raw"):
             return None
+        if output_format == "raw":
+            output_format = self.raw_format
         ext = ".sofa" if output_format == "sofa" else ".h5"
         scenario = kwargs["scenario"]
         split = kwargs.get("dataset_split")
@@ -424,71 +397,85 @@ dataset_split : str or None, optional
         base = (export_dir if export_dir is not None else cache_dir) / "SRIRACHA"
         return base / name
 
-    def _construct_file_name(self, **kwargs) -> str:
-        """Construct HDF5 file name for SRIRACHA."""
-        scenario = kwargs["scenario"]
-        dataset_split = kwargs.get("dataset_split")
-        if dataset_split:
-            return f"{scenario}-{dataset_split}.h5"
-        return f"{scenario}.h5"
 
-    def download(self, **kwargs) -> Path:
-        """Download SRIRACHA HDF5 file (single file only).
+    def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
+        """Return the path to a SRIRACHA HDF5 file, fetching and merging as needed.
+
+        Flow:
+
+        1. If the final file is already on disk, return it.
+        2. For dense scenarios or explicit splits, download a single file.
+        3. For non-dense full-plane scenarios, download the four quadrant
+           files and merge them into one.
 
         Parameters
         ----------
+        cache_dir : Path
+            Cache directory.
+        export_dir : Path or None
+            Optional export directory; takes priority over cache_dir for writes.
         **kwargs
-            Dataset-specific parameters. Must contain 'cache_dir'.
+            Must contain 'scenario'. May contain 'dataset_split'.
 
         Returns
         -------
         Path
-            Path to the downloaded file.
+            Path to the final HDF5 file, ready for ingest().
         """
-        cache_dir = Path(kwargs["cache_dir"]) / "SRIRACHA"
-        cache_dir.mkdir(parents=True, exist_ok=True)
-
-        file_name = self._construct_file_name(**kwargs)
-        file_path = cache_dir / file_name
-
-        # Download if not exists
-        if not file_path.exists():
-            pup = _pooch_from_doi(self.doi, path=cache_dir)
-            _fetch(pup, file_name)
-
-        return file_path
-
-    def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
-        """Check cache or download, with special handling for non-dense full scenarios."""
+        cache_dir = cache_dir / "SRIRACHA"
+        export_dir = export_dir / "SRIRACHA" if export_dir is not None else None
+        target_dir = export_dir if export_dir is not None else cache_dir
         scenario = kwargs["scenario"]
-        dataset_split = kwargs.get("dataset_split")
+        split = kwargs.get("dataset_split")
 
-        # For non-dense scenarios without split, need to download and merge 4 files
-        if not scenario.endswith("-D") and dataset_split is None:
-            return self._download_and_merge(scenario, cache_dir, export_dir, **kwargs)
+        # 1. Final file already on disk?
+        final_name = f"{scenario}-{split}.h5" if split else f"{scenario}.h5"
+        cached = self._lookup(final_name, cache_dir, export_dir)
+        if cached is not None:
+            return cached
 
-        # For all other cases (dense, or with split), use normal flow
-        return super()._get_file(cache_dir, export_dir, **kwargs)
+        # 2a. Dense scenario or explicit split -> single-file download
+        if scenario.endswith("D") or split is not None:
+            target_dir.mkdir(parents=True, exist_ok=True)
+            pup = _pooch_from_doi(self.doi, path=target_dir)
+            _fetch(pup, final_name)
+            return target_dir / final_name
 
-    def _download_and_merge(self, scenario: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
-        """Download and merge four HDF5 split files into one full-plane dataset.
+        # 2b. Non-dense full plane -> download 4 split files and merge
+        return self._download_and_merge(scenario, target_dir)
 
-        This is the same logic as the module-level _download_and_merge but adapted
-        for the Dataset class architecture.
+    def _download_and_merge(self, scenario: str, cache_dir: Path, **kwargs) -> Path:
+        """Download four quadrant HDF5 files and merge them into a full-plane file.
+
+        Reads metadata from the first split, allocates output datasets with the
+        full source-grid shape, copies each split's measurements into the
+        interleaved grid positions, and deletes the split files afterwards.
+
+        Parameters
+        ----------
+        scenario : str
+            Scenario name (e.g. 'SR1').
+        cache_dir : Path
+            Directory where split files are downloaded and the merged file is
+            written.
+
+        Returns
+        -------
+        Path
+            Path to the merged HDF5 file.
         """
-        path = cache_dir / "SRIRACHA"
-        path.mkdir(parents=True, exist_ok=True)
-        output_path = path / f"{scenario}.h5"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        output_path = cache_dir / f"{scenario}.h5"
 
         offsets = {"C1": (0, 0), "C2": (0, 1), "C3": (1, 0), "C4": (1, 1)}
 
         # download split files
         split_files = {}
-        pup = _pooch_from_doi(self.doi, path=path)
+        pup = _pooch_from_doi(self.doi, path=cache_dir)
         for split in offsets:
             fname = f"{scenario}-{split}.h5"
             _fetch(pup, fname)
-            split_files[split] = path / fname
+            split_files[split] = cache_dir / fname
 
         # read shapes and shared metadata from the first split
         with h5.File(split_files["C1"], "r") as f:
@@ -550,3 +537,6 @@ dataset_split : str or None, optional
                 f.unlink()
 
         return output_path
+
+
+

--- a/src/irdl/ista.py
+++ b/src/irdl/ista.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import h5py as h5
 import numpy as np
-import sofar as sf 
+import sofar as sf
 
 from irdl.base import BaseDataset
 from irdl.downloader import CACHE_DIR, _fetch, _pooch_from_doi
@@ -41,17 +41,17 @@ class IstaBaseDataset(BaseDataset):
             SOFA object in the SingleRoomMIMOSRIR convention.
         """
         with h5.File(file_path, "r") as f:
-            ir = f["data"]["impulse_response"][()]              
-            receiver_pos = f["data"]["location"]["receiver"][()]  
-            source_pos = f["data"]["location"]["source"][()]     
+            ir = f["data"]["impulse_response"][()]
+            receiver_pos = f["data"]["location"]["receiver"][()]
+            source_pos = f["data"]["location"]["source"][()]
             sampling_rate = f["metadata"]["sampling_rate"][()]
             temperature = f["metadata"]["temperature"][()]
 
-        # SOFA dimension naming 
-        M, R, N = ir.shape # number of measurements, receiver and samples
-        E = 1 # number of emitters
-        C = 3  # number of coordinates
-        I = 1  # unity dimensions
+        # SOFA dimension naming
+        m, r, n = ir.shape  # number of measurements, receiver and samples
+        e = 1  # number of emitters
+        c = 3  # number of coordinates
+        i = 1  # unity dimensions
 
         sofa = sf.Sofa("SingleRoomMIMOSRIR")
 
@@ -64,35 +64,40 @@ class IstaBaseDataset(BaseDataset):
         sofa.GLOBAL_DatabaseName = self.name.upper()
         sofa.GLOBAL_RoomLocation = "TU Berlin, Einsteinufer 25"
         sofa.GLOBAL_ListenerShortName = "Custom planar microphone array"
-        sofa.GLOBAL_ListenerDescription = "64-channel planar microphone array (1.5 m × 1.5 m aluminium plate, Vogel's spiral, max spacing 1.47 m, 51.2 kHz sampling rate)"
+        sofa.GLOBAL_ListenerDescription = (
+            "64-channel planar microphone array "
+            "(1.5 m × 1.5 m aluminium plate, Vogel's spiral, max spacing 1.47 m, 51.2 kHz sampling rate)"
+        )
         sofa.GLOBAL_ReceiverShortName = "GRAS 40PL-1 Short CCP"
         sofa.GLOBAL_SourceShortName = "Loudspeaker"
-        sofa.GLOBAL_SourceDescription = "Dynamic 2” cone loudspeaker in a cylindrical enclosure (Frequency range 100 Hz–16 kHz)"
-    
-        sofa.RoomVolume = self.room_volume # #Dim. 1, M => so add a dimension upfront
-        
+        sofa.GLOBAL_SourceDescription = (
+            "Dynamic 2” cone loudspeaker in a cylindrical enclosure (Frequency range 100 Hz–16 kHz)"
+        )
+
+        sofa.RoomVolume = self.room_volume  # #Dim. 1, M => so add a dimension upfront
+
         # --- environmental, per-measurement ------------------------------------
-        sofa.RoomTemperature = temperature[..., np.newaxis] #dim spec is (I, M)
+        sofa.RoomTemperature = temperature[np.newaxis, ...]  # dim spec is (I, M)
         sofa.RoomTemperature_Units = "celsius"
-        
+
         # --- geometry ----------------------------------------------------------
         # Receiver: fixed microphone array
-        sofa.ReceiverPosition = receiver_pos.reshape(R, C, I) 
+        sofa.ReceiverPosition = receiver_pos.reshape(r, c, i)
         sofa.ReceiverPosition_Type = "cartesian"
         sofa.ReceiverPosition_Units = "metre"
 
         # Source: one cartesian position per measurement
-        sofa.SourcePosition = source_pos ##dim spec is (M, C)
+        sofa.SourcePosition = source_pos  ##dim spec is (M, C)
 
         # Emitter: single point source, co-located with the source frame origin
-        sofa.EmitterPosition = np.zeros((E, C, I)) 
+        sofa.EmitterPosition = np.zeros((e, c, i))
         sofa.EmitterPosition_Type = "cartesian"
         sofa.EmitterPosition_Units = "metre"
-     
+
         # --- IR data -----------------------------------------------------------
-        sofa.Data_IR = ir[..., np.newaxis] #dim spec (M, R, N, E)
-        sofa.Data_SamplingRate = np.full((I,M), sampling_rate) #dim spec (I, M)
-        sofa.Data_Delay = np.zeros((M, R, I))
+        sofa.Data_IR = ir[..., np.newaxis]  # dim spec (M, R, N, E)
+        sofa.Data_SamplingRate = np.full((i, m), sampling_rate)  # dim spec (I, M)
+        sofa.Data_Delay = np.zeros((m, r, i))
 
         return sofa
 
@@ -103,18 +108,20 @@ class MiracleDataset(IstaBaseDataset):
     name = "miracle"
     doi = "10.14279/depositonce-20837"
     raw_format = "hdf5"
-    room_volume = 830 #metadata needed for creation of sofa file
+    room_volume = 830  # metadata needed for creation of sofa file
 
     @classmethod
     def get(
         cls,
         scenario: str = "A1",
-        dataset_split: str = None,
-        cache_dir: str = CACHE_DIR,
-        export_dir: str = None,
+        dataset_split: str | None = None,
+        cache_dir: str | Path = CACHE_DIR,
+        export_dir: str | Path | None = None,
         output_format: str = "pyfar",
     ):
-        """scenario : str
+        """Select a scenario and optional quadrant split.
+
+        scenario : str
             Scenario to download. One of 'A1', 'A2', 'D1', 'R2'.
         dataset_split : str or None, optional
             Artificial dataset split. One of 'C1', 'C2', 'C3', 'C4' or None.
@@ -128,7 +135,6 @@ class MiracleDataset(IstaBaseDataset):
             export_dir=export_dir,
             output_format=output_format,
         )
-
 
     def _output_path(self, output_format, cache_dir, export_dir, **kwargs):
         """Construct the output path for a MIRACLE file-based output.
@@ -160,7 +166,6 @@ class MiracleDataset(IstaBaseDataset):
         name = f"{scenario}{('-' + split) if split else ''}{ext}"
         base = (export_dir if export_dir is not None else cache_dir) / "MIRACLE"
         return base / name
-    
 
     def validate_params(self, **dataset_kwargs) -> None:
         """Validate MIRACLE-specific parameters.
@@ -188,7 +193,6 @@ class MiracleDataset(IstaBaseDataset):
             raise ValueError("dataset_split must be None or in [C1, C2, C3, C4]")
         if scenario == "D1" and dataset_split is not None:
             raise ValueError("scenario D1 cannot be split")
-
 
     def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
         """Return the path to a MIRACLE HDF5 file, fetching and splitting as needed.
@@ -261,6 +265,7 @@ class MiracleDataset(IstaBaseDataset):
         Path
             Path to the extracted split HDF5 file.
         """
+        cache_dir.mkdir(parents=True, exist_ok=True)
         # Load full data from HDF5
         with h5.File(file_path, "r") as f:
             data = {
@@ -279,10 +284,15 @@ class MiracleDataset(IstaBaseDataset):
         row, column = offsets[dataset_split]
         n = int(np.sqrt(data["source_coordinates"].shape[0]))
         ir_shape = data["impulse_response"].shape
+
         data["source_coordinates"] = data["source_coordinates"].reshape(n, n, 3)[row::2, column::2, :].reshape(-1, 3)
         data["impulse_response"] = (
             data["impulse_response"].reshape(n, n, *ir_shape[1:])[row::2, column::2, :].reshape(-1, *ir_shape[1:])
         )
+        data["temperature"] = data["temperature"].reshape(n, n)[row::2, column::2].reshape(-1)
+        data["speed_of_sound"] = data["speed_of_sound"].reshape(n, n)[row::2, column::2].reshape(-1)
+        if "humidity" in data:
+            data["humidity"] = data["humidity"].reshape(n, n)[row::2, column::2].reshape(-1)
 
         # Save split data to a new HDF5 file
         split_file_name = file_path.stem + f"-{dataset_split}{file_path.suffix}"
@@ -316,12 +326,14 @@ class SrirachaDataset(IstaBaseDataset):
     def get(
         cls,
         scenario: str = "SR1-D",
-        dataset_split: str = None,
-        cache_dir: str = CACHE_DIR,
-        export_dir: str = None,
+        dataset_split: str | None = None,
+        cache_dir: str | Path = CACHE_DIR,
+        export_dir: str | Path | None = None,
         output_format: str = "pyfar",
     ):
-        """scenario : str
+        """Select a scenario and optional quadrant split.
+
+        scenario : str
             Scenario to download. One of 'SR1', 'SRA1', 'SR1-D', 'SRA1-D',
             'SR2', 'SRA2', 'SR2-D', 'SRA2-D'.
         dataset_split : str or None, optional
@@ -337,7 +349,6 @@ class SrirachaDataset(IstaBaseDataset):
             export_dir=export_dir,
             output_format=output_format,
         )
-
 
     def validate_params(self, **dataset_kwargs) -> None:
         """Validate SRIRACHA-specific parameters.
@@ -371,7 +382,6 @@ class SrirachaDataset(IstaBaseDataset):
         if output_format == "raw" and scenario and scenario[-1] != "D" and dataset_split is None:
             raise ValueError("raw output_format not supported for non-dense SRIRACHA scenarios without split")
 
-
     def _output_path(self, output_format, cache_dir, export_dir, **kwargs):
         """Construct the output path for a SRIRACHA file-based output.
 
@@ -402,7 +412,6 @@ class SrirachaDataset(IstaBaseDataset):
         name = f"{scenario}{('-' + split) if split else ''}{ext}"
         base = (export_dir if export_dir is not None else cache_dir) / "SRIRACHA"
         return base / name
-
 
     def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
         """Return the path to a SRIRACHA HDF5 file, fetching and merging as needed.
@@ -450,8 +459,7 @@ class SrirachaDataset(IstaBaseDataset):
         # 2b. Non-dense full plane -> download 4 split files and merge
         return self._download_and_merge(scenario, target_dir)
 
-
-    def _download_and_merge(self, scenario: str, cache_dir: Path, **kwargs) -> Path:
+    def _download_and_merge(self, scenario: str, cache_dir: Path) -> Path:
         """Download four quadrant HDF5 files and merge them into a full-plane file.
 
         Reads metadata from the first split, allocates output datasets with the
@@ -544,6 +552,3 @@ class SrirachaDataset(IstaBaseDataset):
                 f.unlink()
 
         return output_path
-
-
-

--- a/src/irdl/ista.py
+++ b/src/irdl/ista.py
@@ -11,32 +11,99 @@ from typing import Any
 
 import h5py as h5
 import numpy as np
+import sofar as sf
 
 from irdl.base import BaseDataset
 from irdl.downloader import CACHE_DIR, _fetch, _pooch_from_doi
-from irdl.utils import _move_to_export_dir
-
-# =============================================================================
-# Dataset Classes (Phase 2 Migration - ADR-0001)
-# =============================================================================
 
 
-class IstaBaseDataset(BaseDataset, ABC):
-    """Abstract base class for HDF5-based datasets from ISTA (MIRACLE, SRIRACHA).
+class IstaBaseDataset(BaseDataset):
+    """Base class for HDF5-based datasets from ISTA (MIRACLE, SRIRACHA).
 
     Both MIRACLE and SRIRACHA share identical HDF5 file structure and can use
     the same ingestion logic to convert HDF5 to SOFA format.
     """
 
-    @abstractmethod
-    def ingest(self, file_path: Path) -> Any:
-        """Convert HDF5 file to SOFA object.
+    # Room volume for SOFA metadata (subclasses must define)
+    room_volume: float
 
-        Shared implementation for MIRACLE and SRIRACHA since they use
-        identical HDF5 structure.
+    def ingest(self, file_path: Path) -> sf.Sofa:
+        """Convert a MIRACLE/SRIRACHA HDF5 file into a SOFA object.
 
-        TODO: Implement HDF5 -> SOFA conversion
+        Both datasets share an identical HDF5 layout, so this single
+        implementation covers both subclasses. The output follows the
+        SingleRoomMIMOSRIR SOFA convention.
+
+        Parameters
+        ----------
+        file_path : Path
+            Path to the HDF5 file.
+
+        Returns
+        -------
+        sofar.Sofa
+            SOFA object in the SingleRoomMIMOSRIR convention.
         """
+        with h5.File(file_path, "r") as f:
+            ir = f["data"]["impulse_response"][()]
+            receiver_pos = f["data"]["location"]["receiver"][()]
+            source_pos = f["data"]["location"]["source"][()]
+            sampling_rate = f["metadata"]["sampling_rate"][()]
+            temperature = f["metadata"]["temperature"][()]
+
+        # SOFA dimension naming
+        M, R, N = ir.shape  # number of measurements, receiver and samples
+        E = 1  # number of emitters
+        C = 3  # number of coordinates
+        I = 1  # unity dimensions
+
+        sofa = sf.Sofa("SingleRoomMIMOSRIR")
+
+        # --- metadata  -------------------------------------------------
+        sofa.GLOBAL_Title = self.name.upper()
+        sofa.GLOBAL_AuthorContact = "a.pelling@tu-berlin.de; adam.kujawski@tu-berlin.de"
+        sofa.GLOBAL_Organization = "TU Berlin, Department of Engineering Acoustics"
+        sofa.GLOBAL_License = "CC BY-NC-SA 4.0"
+        sofa.GLOBAL_References = self.doi
+        sofa.GLOBAL_DatabaseName = self.name.upper()
+        sofa.GLOBAL_RoomLocation = "TU Berlin, Einsteinufer 25"
+        sofa.GLOBAL_ListenerShortName = "Custom planar microphone array"
+        sofa.GLOBAL_ListenerDescription = (
+            "64-channel planar microphone array "
+            "(1.5 m × 1.5 m aluminium plate, Vogel's spiral, max spacing 1.47 m, 51.2 kHz sampling rate)"
+        )
+        sofa.GLOBAL_ReceiverShortName = "GRAS 40PL-1 Short CCP"
+        sofa.GLOBAL_SourceShortName = "Loudspeaker"
+        sofa.GLOBAL_SourceDescription = (
+            "Dynamic 2\" cone loudspeaker in a cylindrical enclosure (Frequency range 100 Hz–16 kHz)"
+        )
+
+        sofa.RoomVolume = self.room_volume  # Dim. 1, M => so add a dimension upfront
+
+        # --- environmental, per-measurement ------------------------------------
+        sofa.RoomTemperature = temperature[..., np.newaxis]  # dim spec is (I, M)
+        sofa.RoomTemperature_Units = "celsius"
+
+        # --- geometry ----------------------------------------------------------
+        # Receiver: fixed microphone array
+        sofa.ReceiverPosition = receiver_pos.reshape(R, C, I)
+        sofa.ReceiverPosition_Type = "cartesian"
+        sofa.ReceiverPosition_Units = "metre"
+
+        # Source: one cartesian position per measurement
+        sofa.SourcePosition = source_pos  # dim spec is (M, C)
+
+        # Emitter: single point source, co-located with the source frame origin
+        sofa.EmitterPosition = np.zeros((E, C, I))
+        sofa.EmitterPosition_Type = "cartesian"
+        sofa.EmitterPosition_Units = "metre"
+
+        # --- IR data -----------------------------------------------------------
+        sofa.Data_IR = ir[..., np.newaxis]  # dim spec (M, R, N, E)
+        sofa.Data_SamplingRate = np.full((I, M), sampling_rate)  # dim spec (I, M)
+        sofa.Data_Delay = np.zeros((M, R, I))
+
+        return sofa
 
 
 class MiracleDataset(IstaBaseDataset):
@@ -44,9 +111,21 @@ class MiracleDataset(IstaBaseDataset):
 
     name = "miracle"
     doi = "10.14279/depositonce-20837"
+    room_volume = 830  # metadata needed for creation of sofa file
 
-    def validate_params(self, dataset_kwargs: dict) -> None:
-        """Validate MIRACLE-specific parameters."""
+    def validate_params(self, **dataset_kwargs) -> None:
+        """Validate MIRACLE-specific parameters.
+
+        Parameters
+        ----------
+        **dataset_kwargs
+            Dataset-specific parameters to validate. Expected keys: scenario, dataset_split.
+
+        Raises
+        ------
+        ValueError
+            If scenario or split is out of range, or 'D1' is combined with a split.
+        """
         scenario = dataset_kwargs["scenario"]
         dataset_split = dataset_kwargs.get("dataset_split")
 
@@ -61,19 +140,30 @@ class MiracleDataset(IstaBaseDataset):
     def get(
         cls,
         scenario: str = "A1",
-        dataset_split: str = None,
-        cache_dir: str = CACHE_DIR,
-        export_dir: str = None,
+        dataset_split: str | None = None,
+        cache_dir: str | Path = CACHE_DIR,
+        export_dir: str | Path | None = None,
         output_format: str = "pyfar",
     ):
-        """scenario : str
+        """Download MIRACLE dataset.
 
-            Name of the scenario to download. One of 'A1', 'A2', 'D1', 'R2'.
+DOI: 10.14279/depositonce-20837
 
-        dataset_split : str, optional
-            Artificial dataset split. One of 'C1', 'C2', 'C3', 'C4', or None.
-            Dense scenarios (D1) cannot be split.
-        """  # noqa: D400, D403
+Parameters
+----------
+cache_dir : str
+    Cache directory for downloads. Default: user cache directory.
+export_dir : str, optional
+    Directory for final output. Default: None (stays in cache_dir).
+output_format : str
+    Output format: 'pyfar', 'numpy', 'hdf5', 'sofa', or 'raw'.
+
+scenario : str
+    Scenario to download. One of 'A1', 'A2', 'D1', 'R2'.
+dataset_split : str or None, optional
+    Artificial dataset split. One of 'C1', 'C2', 'C3', 'C4' or None.
+    Dense scenarios (D1) cannot be split.
+"""
         instance = cls()
         return instance._get(
             scenario=scenario,
@@ -83,6 +173,34 @@ class MiracleDataset(IstaBaseDataset):
             output_format=output_format,
         )
 
+    def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
+        """Construct the output path for a MIRACLE file-based output.
+
+        Parameters
+        ----------
+        output_format : str
+            One of 'sofa', 'hdf5', 'raw'. Other formats return None.
+        cache_dir : Path
+            Cache directory.
+        export_dir : Path or None
+            Optional export directory; takes priority over cache_dir.
+        **kwargs
+            Must contain 'scenario'. May contain 'dataset_split'.
+
+        Returns
+        -------
+        Path or None
+            Canonical output path under '<base>/MIRACLE/', or None for in-memory formats.
+        """
+        if output_format not in ("sofa", "hdf5", "raw"):
+            return None
+        ext = ".sofa" if output_format == "sofa" else ".h5"
+        scenario = kwargs["scenario"]
+        split = kwargs.get("dataset_split")
+        name = f"{scenario}{('-' + split) if split else ''}{ext}"
+        base = (export_dir if export_dir is not None else cache_dir) / "MIRACLE"
+        return base / name
+
     def _construct_file_name(self, **kwargs) -> str:
         """Construct HDF5 file name for MIRACLE (always full file, splits extracted later)."""
         scenario = kwargs["scenario"]
@@ -90,27 +208,51 @@ class MiracleDataset(IstaBaseDataset):
         return f"{scenario}.h5"
 
     def download(self, **kwargs) -> Path:
-        """Download MIRACLE HDF5 file (always full scenario file)."""
+        """Download MIRACLE HDF5 file (always full scenario file).
+
+        Parameters
+        ----------
+        **kwargs
+            Dataset-specific parameters. Must contain 'cache_dir'.
+
+        Returns
+        -------
+        Path
+            Path to the downloaded file.
+        """
         cache_dir = Path(kwargs["cache_dir"]) / "MIRACLE"
+        cache_dir.mkdir(parents=True, exist_ok=True)
 
         file_name = self._construct_file_name(**kwargs)
         file_path = cache_dir / file_name
 
-        # Check if already exists (handled by _get_file, but download may be called directly)
-        if file_path.exists():
-            return file_path
-
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        pup = _pooch_from_doi(self.doi, path=cache_dir)
-        _fetch(pup, file_name)
+        # Download if not exists
+        if not file_path.exists():
+            pup = _pooch_from_doi(self.doi, path=cache_dir)
+            _fetch(pup, file_name)
 
         return file_path
 
     def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
-        """Check cache or download full file, then split if needed."""
+        """Check cache or download full file, then split if needed.
+
+        Parameters
+        ----------
+        cache_dir : Path
+            Base cache directory.
+        export_dir : Path or None
+            Optional export directory.
+        **kwargs
+            Dataset-specific parameters. Must contain 'scenario'. May contain 'dataset_split'.
+
+        Returns
+        -------
+        Path
+            Path to the file ready for ingest().
+        """
         dataset_split = kwargs.get("dataset_split")
 
-        # Download/get the full file
+        # Download/get the full file using parent's _get_file
         file_path = super()._get_file(cache_dir, export_dir, **kwargs)
 
         # If a split is requested, extract it from the full file
@@ -160,11 +302,12 @@ class MiracleDataset(IstaBaseDataset):
         )
 
         # Save split data to a new HDF5 file
-        split_file_name = file_path.stem + f"-{dataset_split}{file_path.suffix}"
+        split_file_name = f"{file_path.stem}-{dataset_split}{file_path.suffix}"
         if export_dir:
-            split_path = Path(export_dir) / split_file_name
+            split_path = Path(export_dir) / "MIRACLE" / split_file_name
         else:
             split_path = file_path.parent / split_file_name
+        split_path.parent.mkdir(parents=True, exist_ok=True)
 
         with h5.File(split_path, "w") as f:
             data_group = f.create_group("data")
@@ -187,45 +330,63 @@ class SrirachaDataset(IstaBaseDataset):
 
     name = "sriracha"
     doi = "10.14279/depositonce-23943"
+    room_volume = 73.5
 
-    def validate_params(self, dataset_kwargs: dict) -> None:
-        """Validate SRIRACHA-specific parameters."""
-        scenario = dataset_kwargs["scenario"]
+    def validate_params(self, **dataset_kwargs) -> None:
+        """Validate SRIRACHA-specific parameters.
+
+        Parameters
+        ----------
+        **dataset_kwargs
+            Dataset-specific parameters to validate. Expected keys: scenario, dataset_split.
+
+        Raises
+        ------
+        ValueError
+            If scenario, split, or output_format combination is invalid.
+        """
+        output_format = dataset_kwargs.get("output_format")
+        scenario = dataset_kwargs.get("scenario")
         dataset_split = dataset_kwargs.get("dataset_split")
 
         if scenario not in ["SR1", "SRA1", "SR1-D", "SRA1-D", "SR2", "SRA2", "SR2-D", "SRA2-D"]:
             raise ValueError("scenario must be one of [SR1, SRA1, SR1-D, SRA1-D, SR2, SRA2, SR2-D, SRA2-D]")
         if dataset_split not in [None, "C1", "C2", "C3", "C4"]:
             raise ValueError("dataset_split must be None or in [C1, C2, C3, C4]")
-        if scenario[-1] == "D" and dataset_split is not None:
+        if scenario.endswith("-D") and dataset_split is not None:
             raise ValueError("dense datasets do not have splits")
-
-    def validate_output_format(self, output_format: str, **dataset_kwargs) -> None:
-        """Validate output_format in context of SRIRACHA dataset parameters."""
-        scenario = dataset_kwargs.get("scenario")
-        dataset_split = dataset_kwargs.get("dataset_split")
-        # raw output_format not allowed for non-dense full scenarios
-        if output_format == "raw" and scenario and scenario[-1] != "D" and dataset_split is None:
+        if output_format == "raw" and scenario and not scenario.endswith("-D") and dataset_split is None:
             raise ValueError("raw output_format not supported for non-dense SRIRACHA scenarios without split")
 
     @classmethod
     def get(
         cls,
         scenario: str = "SR1-D",
-        dataset_split: str = None,
-        cache_dir: str = CACHE_DIR,
-        export_dir: str = None,
+        dataset_split: str | None = None,
+        cache_dir: str | Path = CACHE_DIR,
+        export_dir: str | Path | None = None,
         output_format: str = "pyfar",
     ):
-        """scenario : str
+        """Download SRIRACHA dataset.
 
-            Name of the scenario to download. One of 'SR1', 'SRA1', 'SR1-D',
-            'SRA1-D', 'SR2', 'SRA2', 'SR2-D', or 'SRA2-D'.
+DOI: 10.14279/depositonce-23943
 
-        dataset_split : str, optional
-            Optional dataset split for full-plane scenarios. One of 'C1', 'C2',
-            'C3', 'C4', or None. Dense scenarios (ending in -D) do not have splits.
-        """  # noqa: D400, D403
+Parameters
+----------
+cache_dir : str
+    Cache directory for downloads. Default: user cache directory.
+export_dir : str, optional
+    Directory for final output. Default: None (stays in cache_dir).
+output_format : str
+    Output format: 'pyfar', 'numpy', 'hdf5', 'sofa', or 'raw'.
+
+scenario : str
+    Scenario to download. One of 'SR1', 'SRA1', 'SR1-D', 'SRA1-D', 'SR2',
+    'SRA2', 'SR2-D', or 'SRA2-D'.
+dataset_split : str or None, optional
+    Optional dataset split for full-plane scenarios. One of 'C1', 'C2',
+    'C3', 'C4', or None. Dense scenarios (ending in -D) do not have splits.
+"""
         instance = cls()
         return instance._get(
             scenario=scenario,
@@ -234,6 +395,34 @@ class SrirachaDataset(IstaBaseDataset):
             export_dir=export_dir,
             output_format=output_format,
         )
+
+    def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
+        """Construct the output path for a SRIRACHA file-based output.
+
+        Parameters
+        ----------
+        output_format : str
+            One of 'sofa', 'hdf5', 'raw'. Other formats return None.
+        cache_dir : Path
+            Cache directory.
+        export_dir : Path or None
+            Optional export directory; takes priority over cache_dir.
+        **kwargs
+            Must contain 'scenario'. May contain 'dataset_split'.
+
+        Returns
+        -------
+        Path or None
+            Canonical output path under '<base>/SRIRACHA/', or None for in-memory formats.
+        """
+        if output_format not in ("sofa", "hdf5", "raw"):
+            return None
+        ext = ".sofa" if output_format == "sofa" else ".h5"
+        scenario = kwargs["scenario"]
+        split = kwargs.get("dataset_split")
+        name = f"{scenario}{('-' + split) if split else ''}{ext}"
+        base = (export_dir if export_dir is not None else cache_dir) / "SRIRACHA"
+        return base / name
 
     def _construct_file_name(self, **kwargs) -> str:
         """Construct HDF5 file name for SRIRACHA."""
@@ -244,18 +433,28 @@ class SrirachaDataset(IstaBaseDataset):
         return f"{scenario}.h5"
 
     def download(self, **kwargs) -> Path:
-        """Download SRIRACHA HDF5 file (single file only)."""
+        """Download SRIRACHA HDF5 file (single file only).
+
+        Parameters
+        ----------
+        **kwargs
+            Dataset-specific parameters. Must contain 'cache_dir'.
+
+        Returns
+        -------
+        Path
+            Path to the downloaded file.
+        """
         cache_dir = Path(kwargs["cache_dir"]) / "SRIRACHA"
+        cache_dir.mkdir(parents=True, exist_ok=True)
 
         file_name = self._construct_file_name(**kwargs)
         file_path = cache_dir / file_name
 
-        if file_path.exists():
-            return file_path
-
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        pup = _pooch_from_doi(self.doi, path=cache_dir)
-        _fetch(pup, file_name)
+        # Download if not exists
+        if not file_path.exists():
+            pup = _pooch_from_doi(self.doi, path=cache_dir)
+            _fetch(pup, file_name)
 
         return file_path
 
@@ -265,7 +464,7 @@ class SrirachaDataset(IstaBaseDataset):
         dataset_split = kwargs.get("dataset_split")
 
         # For non-dense scenarios without split, need to download and merge 4 files
-        if scenario[-1] != "D" and dataset_split is None:
+        if not scenario.endswith("-D") and dataset_split is None:
             return self._download_and_merge(scenario, cache_dir, export_dir, **kwargs)
 
         # For all other cases (dense, or with split), use normal flow
@@ -349,9 +548,5 @@ class SrirachaDataset(IstaBaseDataset):
             # delete split files
             for f in split_files.values():
                 f.unlink()
-
-        # Move to export_dir if specified
-        if export_dir is not None:
-            return _move_to_export_dir(output_path, export_dir)
 
         return output_path

--- a/src/irdl/repositories.py
+++ b/src/irdl/repositories.py
@@ -31,6 +31,7 @@
 
 from time import sleep
 
+import pooch as po
 import requests
 from pooch import get_logger
 from pooch.downloaders import (
@@ -52,8 +53,14 @@ MAX_RETRIES = 5
 BACKOFF_FACTOR = 2.0  # exponential backoff: waits 2, 4, 8, 16, 32 s between retries
 
 
-def _make_session():
-    """Create a requests Session with automatic retry and exponential backoff."""
+def _make_session() -> requests.Session:
+    """Create a requests Session with automatic retry and exponential backoff.
+
+    Returns
+    -------
+    requests.Session
+        Session with automatic retry and exponential backoff configured.
+    """
     session = requests.Session()
     retry = Retry(
         total=MAX_RETRIES,
@@ -69,27 +76,43 @@ def _make_session():
 
 
 class DSpaceRepository(DataRepository):
-    def __init__(self, doi, archive_url):
+    """DSpace repository implementation for DepositOnce.
+
+    Attributes
+    ----------
+    archive_url : str
+        The archive URL for the repository.
+    doi : str
+        The DOI of the archive.
+    _api_response : dict or None
+        Cached API response from the repository.
+    """
+
+    def __init__(self, doi: str, archive_url: str):
         self.archive_url = archive_url
         self.doi = doi
         self._api_response = None
 
     @classmethod
-    def initialize(cls, doi, archive_url):
+    def initialize(cls, doi: str, archive_url: str) -> DataRepository | None:
         """Initialize the data repository if the given URL points to a corresponding repository.
 
         Initializes a data repository object. This is done as part of
         a chain of responsibility. If the class cannot handle the given
-        repository URL, it returns `None`. Otherwise a `DSpaceRepository`
+        repository URL, it returns None. Otherwise a DSpaceRepository
         instance is returned.
 
         Parameters
         ----------
-        doi : :class:`str`
+        doi : str
             The DOI that identifies the repository.
-        archive_url : :class:`str`
+        archive_url : str
             The resolved URL for the DOI.
 
+        Returns
+        -------
+        DSpaceRepository or None
+            DSpaceRepository instance if URL matches, None otherwise.
         """
         # Check whether this is a Figshare URL
         parsed_archive_url = parse_url(archive_url)
@@ -99,7 +122,19 @@ class DSpaceRepository(DataRepository):
         return cls(doi, archive_url)
 
     @property
-    def api_response(self):
+    def api_response(self) -> dict:
+        """Get the API response, fetching from server if not cached.
+
+        Returns
+        -------
+        dict
+            API response containing file metadata.
+
+        Raises
+        ------
+        ValueError
+            If no 'ORIGINAL' bundle is found for the item.
+        """
         if self._api_response is None:
             article_id = self.archive_url.split("/")[-1]
             with _make_session() as session:
@@ -132,45 +167,45 @@ class DSpaceRepository(DataRepository):
 
         return self._api_response
 
-    def download_url(self, file_name):
+    def download_url(self, file_name: str) -> str:
         """Use the repository API to get the download URL for a file given the archive URL.
 
         Parameters
         ----------
-        file_name : :class:`str`
+        file_name : str
             The name of the file in the archive that will be downloaded.
 
         Returns
         -------
-        download_url : :class:`str`
+        download_url : str
             The HTTP URL that can be used to download the file.
 
         """
         return self.api_response[file_name]["url"]
 
-    def file_size(self, file_name):
-        """Return the size of a file in bytes, or ``None`` if unavailable.
+    def file_size(self, file_name: str) -> int | None:
+        """Return the size of a file in bytes, or None if unavailable.
 
         Parameters
         ----------
-        file_name : :class:`str`
+        file_name : str
             The name of the file in the archive.
 
         Returns
         -------
-        size : :class:`int` or None
+        size : int or None
             The file size in bytes.
 
         """
         return self.api_response[file_name].get("size")
 
 
-    def populate_registry(self, pooch):
+    def populate_registry(self, pooch: po.Pooch) -> None:
         """Populate the registry using the data repository's API.
 
         Parameters
         ----------
-        pooch : :class:`pooch.Pooch`
+        pooch : pooch.Pooch
             The pooch instance that the registry will be added to.
 
         """
@@ -178,7 +213,7 @@ class DSpaceRepository(DataRepository):
             pooch.registry[name] = info["checksum"]
 
 
-def doi_to_repository(doi):
+def doi_to_repository(doi: str) -> DataRepository:
     """Instantiate a data repository instance from a given DOI.
 
     This function implements the chain of responsibility dispatch
@@ -186,14 +221,20 @@ def doi_to_repository(doi):
 
     Parameters
     ----------
-    doi : :class:`str`
+    doi : str
         The DOI of the archive.
 
     Returns
     -------
-    data_repository : :class:`DataRepository`
+    data_repository : DataRepository
         The data repository object.
 
+    Raises
+    ------
+    ConnectionError
+        If the DOI cannot be resolved to a URL.
+    ValueError
+        If no repository can handle the given URL.
     """
     # This should go away in a separate issue: DOI handling should
     # not rely on the (non-)existence of trailing slashes. The issue

--- a/src/irdl/sofa.py
+++ b/src/irdl/sofa.py
@@ -15,7 +15,7 @@ from irdl.downloader import CACHE_DIR, _fetch, _pooch_from_doi
 
 
 class FabianDataset(BaseDataset):
-    """Implement FABIAN HRTF Database Dataset.
+    """Download and extract the FABIAN HRTF Database from DepositOnce.
 
     Attributes
     ----------

--- a/src/irdl/sofa.py
+++ b/src/irdl/sofa.py
@@ -76,14 +76,14 @@ class FabianDataset(BaseDataset):
 
         Parameters
         ----------
-        target_path : Path
+        target_path : :class:`pathlib.Path`
             Target path where the SOFA file should be extracted.
         **kwargs : dict
             Expected keys: kind, hato.
 
         Returns
         -------
-        Path
+        :class:`pathlib.Path`
             Path to the extracted SOFA file.
         """
         base_dir = target_path.parent
@@ -135,12 +135,12 @@ class FabianDataset(BaseDataset):
 
         Parameters
         ----------
-        file_path : Path
+        file_path : :class:`pathlib.Path`
             Path to the SOFA file.
 
         Returns
         -------
-        sofar.Sofa
+        :class:`sofar.Sofa`
             SOFA object containing the dataset data.
         """
         return sf.read_sofa(str(file_path))

--- a/src/irdl/sofa.py
+++ b/src/irdl/sofa.py
@@ -50,36 +50,10 @@ class FabianDataset(BaseDataset):
         if hato not in [0, 10, 20, 30, 40, 50, 310, 320, 330, 340, 350]:
             raise ValueError("hato must be one of [0, 10, 20, 30, 40, 50, 310, 320, 330, 340, 350]")
 
-    def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
-        """Construct the output path for a FABIAN file-based output.
+    def _source_filename(self, **kwargs) -> str:
+        """Construct the raw input filename with extension.
 
-        Parameters
-        ----------
-        output_format : str
-            One of 'sofa', 'hdf5', 'raw'. Other formats return None.
-        cache_dir : Path
-            Cache directory.
-        export_dir : Path or None
-            Optional export directory; takes priority over cache_dir.
-        **kwargs
-            Must contain 'kind' and 'hato'.
-
-        Returns
-        -------
-        Path or None
-            Canonical output path under '<base>/FABIAN/', or None for in-memory formats.
-        """
-        if output_format not in ("sofa", "hdf5", "raw"):
-            return None
-        ext = ".sofa" if output_format == "sofa" else ".h5"
-        kind = kwargs["kind"]
-        hato = kwargs["hato"]
-        name = f"FABIAN_HRIR_{kind}_HATO_{hato}{ext}"
-        base = (export_dir if export_dir is not None else cache_dir) / "FABIAN"
-        return base / name
-
-    def _construct_file_name(self, **kwargs) -> str:
-        """Construct file name based on kind and hato parameters.
+        For FABIAN, this is the SOFA file that gets extracted from the ZIP archive.
 
         Parameters
         ----------
@@ -95,65 +69,49 @@ class FabianDataset(BaseDataset):
         hato = kwargs["hato"]
         return f"FABIAN_HRIR_{kind}_HATO_{hato}.sofa"
 
-    def download(self, **kwargs) -> Path:
-        """Download FABIAN ZIP archive.
+    def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
+        """Return the path to a FABIAN SOFA file, extracting from ZIP if needed.
 
         Parameters
         ----------
-        **kwargs : :class:`dict`
-            Expected keys: kind, hato, cache_dir.
-
-        Returns
-        -------
-        :class:`pathlib.Path`
-            Path to the downloaded ZIP file.
-        """
-        cache_dir = Path(kwargs.get("cache_dir", CACHE_DIR)) / "FABIAN"
-        cache_dir.mkdir(parents=True, exist_ok=True)
-
-        zipfile_name = "FABIAN_HRTF_DATABASE_v4.zip"
-        zip_path = cache_dir / zipfile_name
-
-        # Download ZIP archive if not exists
-        if not zip_path.exists():
-            pup = _pooch_from_doi(self.doi, path=cache_dir)
-            _fetch(pup, zipfile_name)
-
-        return zip_path
-
-    def _process(self, file_path: Path, **kwargs) -> Path:
-        """Extract SOFA file from FABIAN ZIP archive.
-
-        Parameters
-        ----------
-        file_path : :class:`pathlib.Path`
-            Path to the ZIP file.
+        cache_dir : :class:`pathlib.Path`
+            Base cache directory.
+        export_dir : :class:`pathlib.Path` or :class:`None`
+            Optional export directory; takes priority over cache_dir.
         **kwargs : :class:`dict`
             Expected keys: kind, hato.
 
         Returns
         -------
         :class:`pathlib.Path`
-            Path to the extracted SOFA file.
+            Path to the SOFA file, ready for ingest().
         """
-        kind = kwargs["kind"]
-        hato = kwargs["hato"]
-        cache_dir = file_path.parent
-        base_name = f"FABIAN_HRIR_{kind}_HATO_{hato}"
-        sofa_path = cache_dir / f"{base_name}.sofa"
+        # Get the expected SOFA file path
+        sofa_path = self._input_path(cache_dir, export_dir, **kwargs)
 
         # Check if SOFA file already exists
         if sofa_path.exists():
             return sofa_path
 
+        # Need to download and extract from ZIP
+        base_dir = (export_dir if export_dir is not None else cache_dir) / self.name.upper()
+        base_dir.mkdir(parents=True, exist_ok=True)
+
+        # Download ZIP if needed
+        zipfile_name = "FABIAN_HRTF_DATABASE_v4.zip"
+        zip_path = base_dir / zipfile_name
+        if not zip_path.exists():
+            pup = _pooch_from_doi(self.doi, path=base_dir)
+            _fetch(pup, zipfile_name)
+
         # Extract SOFA file from ZIP
         logger = po.get_logger()
-        with ZipFile(file_path, "r") as zf:
+        with ZipFile(zip_path, "r") as zf:
             for name in zf.namelist():
                 if name.endswith(sofa_path.name):
                     zf.getinfo(name).filename = Path(name).name
                     logger.info(f"Extracting {name} to {sofa_path}")
-                    zf.extract(name, path=cache_dir)
+                    zf.extract(name, path=sofa_path.parent)
 
         return sofa_path
 

--- a/src/irdl/sofa.py
+++ b/src/irdl/sofa.py
@@ -9,6 +9,7 @@ from typing import Any
 from zipfile import ZipFile
 
 import pooch as po
+import sofa as sf
 
 from irdl.base import BaseDataset
 from irdl.downloader import CACHE_DIR, _fetch, _pooch_from_doi
@@ -28,13 +29,18 @@ class FabianDataset(BaseDataset):
     name = "fabian"
     doi = "10.14279/depositonce-5718.5"
 
-    def validate_params(self, dataset_kwargs: dict) -> None:
+    def validate_params(self, **dataset_kwargs) -> None:
         """Validate FABIAN-specific parameters.
 
         Parameters
         ----------
-        dataset_kwargs : :class:`dict`
+        **dataset_kwargs
             Parameters to validate. Expected keys: kind, hato.
+
+        Raises
+        ------
+        ValueError
+            If kind or hato is out of range.
         """
         kind = dataset_kwargs["kind"]
         hato = dataset_kwargs["hato"]
@@ -43,6 +49,34 @@ class FabianDataset(BaseDataset):
             raise ValueError("kind must be either 'measured' or 'modeled'")
         if hato not in [0, 10, 20, 30, 40, 50, 310, 320, 330, 340, 350]:
             raise ValueError("hato must be one of [0, 10, 20, 30, 40, 50, 310, 320, 330, 340, 350]")
+
+    def _output_path(self, output_format: str, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path | None:
+        """Construct the output path for a FABIAN file-based output.
+
+        Parameters
+        ----------
+        output_format : str
+            One of 'sofa', 'hdf5', 'raw'. Other formats return None.
+        cache_dir : Path
+            Cache directory.
+        export_dir : Path or None
+            Optional export directory; takes priority over cache_dir.
+        **kwargs
+            Must contain 'kind' and 'hato'.
+
+        Returns
+        -------
+        Path or None
+            Canonical output path under '<base>/FABIAN/', or None for in-memory formats.
+        """
+        if output_format not in ("sofa", "hdf5", "raw"):
+            return None
+        ext = ".sofa" if output_format == "sofa" else ".h5"
+        kind = kwargs["kind"]
+        hato = kwargs["hato"]
+        name = f"FABIAN_HRIR_{kind}_HATO_{hato}{ext}"
+        base = (export_dir if export_dir is not None else cache_dir) / "FABIAN"
+        return base / name
 
     def _construct_file_name(self, **kwargs) -> str:
         """Construct file name based on kind and hato parameters.
@@ -128,18 +162,29 @@ class FabianDataset(BaseDataset):
         cls,
         kind: str = "measured",
         hato: int = 0,
-        cache_dir: str = CACHE_DIR,
-        export_dir: str = None,
+        cache_dir: str | Path = CACHE_DIR,
+        export_dir: str | Path | None = None,
         output_format: str = "pyfar",
     ):
-        """kind : str
+        """Download FABIAN dataset.
 
-            Type of HRTF to download. Either 'measured' or 'modeled'.
+DOI: 10.14279/depositonce-5718.5
 
-        hato : int
-            Head-above-torso-rotation of HRTFs in degrees.
-            One of: 0, 10, 20, 30, 40, 50, 310, 320, 330, 340, 350.
-        """  # noqa: D400, D403
+Parameters
+----------
+cache_dir : str
+    Cache directory for downloads. Default: user cache directory.
+export_dir : str, optional
+    Directory for final output. Default: None (stays in cache_dir).
+output_format : str
+    Output format: 'pyfar', 'numpy', 'hdf5', 'sofa', or 'raw'.
+
+kind : str
+    Type of HRTF to download. Either 'measured' or 'modeled'.
+hato : int
+    Head-above-torso-rotation of HRTFs in degrees.
+    One of: 0, 10, 20, 30, 40, 50, 310, 320, 330, 340, 350.
+"""
         instance = cls()
         return instance._get(
             kind=kind,
@@ -149,7 +194,7 @@ class FabianDataset(BaseDataset):
             output_format=output_format,
         )
 
-    def ingest(self, file_path: Path) -> Any:
+    def ingest(self, file_path: Path) -> sf.Sofa:
         """Load SOFA file into :class:`sofar.Sofa` object.
 
         Parameters
@@ -162,6 +207,4 @@ class FabianDataset(BaseDataset):
         :class:`sofar.Sofa`
             SOFA object containing the dataset data.
         """
-        import sofar as sf
-
         return sf.read_sofa(str(file_path))

--- a/src/irdl/sofa.py
+++ b/src/irdl/sofa.py
@@ -5,11 +5,10 @@ architecture, along with legacy helper functions for backwards compatibility.
 """
 
 from pathlib import Path
-from typing import Any
 from zipfile import ZipFile
 
 import pooch as po
-import sofa as sf
+import sofar as sf
 
 from irdl.base import BaseDataset
 from irdl.downloader import CACHE_DIR, _fetch, _pooch_from_doi
@@ -20,9 +19,9 @@ class FabianDataset(BaseDataset):
 
     Attributes
     ----------
-    name : :class:`str`
+    name : str
         Dataset name ("fabian").
-    doi : :class:`str`
+    doi : str
         Digital Object Identifier ("10.14279/depositonce-5718.5").
     """
 
@@ -34,7 +33,7 @@ class FabianDataset(BaseDataset):
 
         Parameters
         ----------
-        **dataset_kwargs
+        **dataset_kwargs : dict
             Parameters to validate. Expected keys: kind, hato.
 
         Raises
@@ -57,45 +56,37 @@ class FabianDataset(BaseDataset):
 
         Parameters
         ----------
-        **kwargs : :class:`dict`
+        **kwargs : dict
             Expected keys: kind, hato.
 
         Returns
         -------
-        :class:`str`
+        str
             File name in format "FABIAN_HRIR_{kind}_HATO_{hato}.sofa".
         """
         kind = kwargs["kind"]
         hato = kwargs["hato"]
         return f"FABIAN_HRIR_{kind}_HATO_{hato}.sofa"
 
-    def _get_file(self, cache_dir: Path, export_dir: Path | None, **kwargs) -> Path:
-        """Return the path to a FABIAN SOFA file, extracting from ZIP if needed.
+    def download(self, target_path: Path, **kwargs) -> Path:
+        """Download FABIAN dataset and extract the requested SOFA file.
+
+        Downloads the ZIP archive if needed, then extracts the specific SOFA file
+        based on kind and hato parameters.
 
         Parameters
         ----------
-        cache_dir : :class:`pathlib.Path`
-            Base cache directory.
-        export_dir : :class:`pathlib.Path` or :class:`None`
-            Optional export directory; takes priority over cache_dir.
-        **kwargs : :class:`dict`
+        target_path : Path
+            Target path where the SOFA file should be extracted.
+        **kwargs : dict
             Expected keys: kind, hato.
 
         Returns
         -------
-        :class:`pathlib.Path`
-            Path to the SOFA file, ready for ingest().
+        Path
+            Path to the extracted SOFA file.
         """
-        # Get the expected SOFA file path
-        sofa_path = self._input_path(cache_dir, export_dir, **kwargs)
-
-        # Check if SOFA file already exists
-        if sofa_path.exists():
-            return sofa_path
-
-        # Need to download and extract from ZIP
-        base_dir = (export_dir if export_dir is not None else cache_dir) / self.name.upper()
-        base_dir.mkdir(parents=True, exist_ok=True)
+        base_dir = target_path.parent
 
         # Download ZIP if needed
         zipfile_name = "FABIAN_HRTF_DATABASE_v4.zip"
@@ -108,12 +99,12 @@ class FabianDataset(BaseDataset):
         logger = po.get_logger()
         with ZipFile(zip_path, "r") as zf:
             for name in zf.namelist():
-                if name.endswith(sofa_path.name):
+                if name.endswith(target_path.name):
                     zf.getinfo(name).filename = Path(name).name
-                    logger.info(f"Extracting {name} to {sofa_path}")
-                    zf.extract(name, path=sofa_path.parent)
+                    logger.info(f"Extracting {name} to {target_path}")
+                    zf.extract(name, path=base_dir)
 
-        return sofa_path
+        return target_path
 
     @classmethod
     def get(
@@ -124,27 +115,14 @@ class FabianDataset(BaseDataset):
         export_dir: str | Path | None = None,
         output_format: str = "pyfar",
     ):
-        """Download FABIAN dataset.
-
-DOI: 10.14279/depositonce-5718.5
-
-Parameters
-----------
-cache_dir : str
-    Cache directory for downloads. Default: user cache directory.
-export_dir : str, optional
-    Directory for final output. Default: None (stays in cache_dir).
-output_format : str
-    Output format: 'pyfar', 'numpy', 'hdf5', 'sofa', or 'raw'.
-
-kind : str
-    Type of HRTF to download. Either 'measured' or 'modeled'.
-hato : int
-    Head-above-torso-rotation of HRTFs in degrees.
-    One of: 0, 10, 20, 30, 40, 50, 310, 320, 330, 340, 350.
-"""
-        instance = cls()
-        return instance._get(
+        """
+        kind : str, optional
+            Type of HRTF to download. Either 'measured' or 'modeled'. Default is 'measured'.
+        hato : int, optional
+            Head-above-torso-rotation of HRTFs in degrees.
+            One of: 0, 10, 20, 30, 40, 50, 310, 320, 330, 340, 350. Default is 0.
+        """  # noqa: D205, D403
+        return cls()._get(
             kind=kind,
             hato=hato,
             cache_dir=cache_dir,
@@ -153,16 +131,16 @@ hato : int
         )
 
     def ingest(self, file_path: Path) -> sf.Sofa:
-        """Load SOFA file into :class:`sofar.Sofa` object.
+        """Load SOFA file into sofar.Sofa object.
 
         Parameters
         ----------
-        file_path : :class:`pathlib.Path`
+        file_path : Path
             Path to the SOFA file.
 
         Returns
         -------
-        :class:`sofar.Sofa`
+        sofar.Sofa
             SOFA object containing the dataset data.
         """
         return sf.read_sofa(str(file_path))

--- a/src/irdl/utils.py
+++ b/src/irdl/utils.py
@@ -1,6 +1,5 @@
 import warnings
 
-
 import psutil
 
 
@@ -33,6 +32,3 @@ def _fits_in_memory(file_path):
             stacklevel=2,
         )
         return False
-
-
-

--- a/src/irdl/utils.py
+++ b/src/irdl/utils.py
@@ -1,9 +1,12 @@
+"""Utility functions for IRDL."""
+
 import warnings
+from pathlib import Path
 
 import psutil
 
 
-def _fits_in_memory(file_path):
+def _fits_in_memory(file_path: Path) -> bool:
     """Check if a file can be loaded into available RAM.
 
     Needed for pyfar or numpy output formats, which load the entire dataset into memory.
@@ -18,6 +21,10 @@ def _fits_in_memory(file_path):
     fits : bool
         True if the file fits into available RAM with headroom.
 
+    Warnings
+    --------
+    UserWarning
+        If the file does not fit into available RAM.
     """
     file_size = file_path.stat().st_size
     available = psutil.virtual_memory().available

--- a/src/irdl/utils.py
+++ b/src/irdl/utils.py
@@ -1,6 +1,5 @@
-import shutil
 import warnings
-from pathlib import Path
+
 
 import psutil
 
@@ -36,31 +35,4 @@ def _fits_in_memory(file_path):
         return False
 
 
-def _move_to_export_dir(cached_path, export_dir):
-    """Move a file from the cache directory to a dedicated export directory.
 
-    Parameters
-    ----------
-    cached_path : :class:`pathlib.Path`
-        Path to the file in the cache directory.
-    export_dir : :class:`str`, :class:`pathlib.Path`, or None
-        Directory to move the file to. If ``None`` or identical to the file's
-        parent directory, the file is not moved and ``cached_path`` is returned.
-
-    Returns
-    -------
-    path : :class:`pathlib.Path`
-        Path to the file, either in ``export_dir`` or unchanged if no move was needed.
-
-    """
-    # no export_dir specified
-    if export_dir is None or Path(export_dir) == cached_path.parent:
-        return cached_path
-    dest = Path(export_dir) / cached_path.name
-    # file exists already in export_dir
-    if dest.exists():
-        return dest
-    # move file from cache to export_dir
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(cached_path, dest)
-    return dest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,12 +30,8 @@ def sofa_object():
 
     # Set coordinates: shape (n_positions, 3) where each row is (x, y, z)
     # SOFA uses (M, C) or (I, C) where C=3 for (x, y, z)
-    sofa.SourcePosition = np.array(
-        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float64
-    )  # Shape: (n_sources, 3)
-    sofa.ReceiverPosition = np.array(
-        [[0.0, 0.5, 0.0], [0.0, -0.5, 0.0]], dtype=np.float64
-    )  # Shape: (n_receivers, 3)
+    sofa.SourcePosition = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float64)  # Shape: (n_sources, 3)
+    sofa.ReceiverPosition = np.array([[0.0, 0.5, 0.0], [0.0, -0.5, 0.0]], dtype=np.float64)  # Shape: (n_receivers, 3)
 
     # Data_Delay is required for GeneralFIR convention
     sofa.Data_Delay = np.zeros(n_sources, dtype=np.float32)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -17,7 +17,7 @@ class TestBaseDatasetAbstract:
     def test_abstract_methods_defined(self):
         """Verify BaseDataset has expected abstract methods."""
         expected_abstract = {
-            "_construct_file_name",
+            "_source_filename",
             "download",
             "ingest",
             "validate_params",
@@ -35,11 +35,9 @@ class TestIstaBaseDatasetAbstract:
 
     def test_inherits_abstract_methods(self):
         """Verify IstaBaseDataset inherits and adds abstract methods."""
-        # IstaBaseDataset should have all BaseDataset abstract methods plus its own
+        # IstaBaseDataset implements _source_filename and ingest, so only download and validate_params are abstract
         expected_abstract = {
-            "_construct_file_name",
             "download",
-            "ingest",
             "validate_params",
         }
         assert IstaBaseDataset.__abstractmethods__ == expected_abstract

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -29,7 +29,7 @@ class TestDataset(BaseDataset):
         """No-op ingest for test dataset."""
         pass
 
-    def _construct_file_name(self, **kwargs):
+    def _source_filename(self, **kwargs):
         """Return test file name."""
         return "test.sofa"
 
@@ -115,13 +115,13 @@ class TestConversionToSofa:
     def test_conversion_to_sofa_returns_path(self, sofa_object):
         """Verify _to_sofa returns a Path object."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            result = test_dataset._to_sofa(sofa_object, Path(tmpdir), None)
+            result = test_dataset._to_sofa(sofa_object, Path(tmpdir) / "test.sofa")
             assert isinstance(result, Path)
             assert result.exists()
 
     def test_conversion_to_sofa_writable(self, sofa_object, tmp_path):
         """Verify _to_sofa writes a valid SOFA file."""
-        result = test_dataset._to_sofa(sofa_object, Path(tmp_path), None)
+        result = test_dataset._to_sofa(sofa_object, Path(tmp_path) / "test.sofa")
 
         # Verify file can be read back
         loaded_sofa = sf.read_sofa(str(result))
@@ -135,7 +135,7 @@ class TestConversionToHdf5:
     def test_conversion_to_hdf5_returns_path(self, sofa_object):
         """Verify _to_hdf5 returns a Path object."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            result = test_dataset._to_hdf5(sofa_object, Path(tmpdir), None)
+            result = test_dataset._to_hdf5(sofa_object, Path(tmpdir) / "test.h5")
             assert isinstance(result, Path)
             assert result.exists()
 
@@ -144,7 +144,7 @@ class TestConversionToHdf5:
         import h5py
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            result = test_dataset._to_hdf5(sofa_object, Path(tmpdir), None)
+            result = test_dataset._to_hdf5(sofa_object, Path(tmpdir) / "test.h5")
 
             with h5py.File(result, "r") as f:
                 # Check data group exists
@@ -169,7 +169,7 @@ class TestConversionToHdf5:
         sofa_object.Data_Humidity = np.array([50.0, 50.0])
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            result = test_dataset._to_hdf5(sofa_object, Path(tmpdir), None)
+            result = test_dataset._to_hdf5(sofa_object, Path(tmpdir) / "test.h5")
 
             with h5py.File(result, "r") as f:
                 assert "temperature" in f["metadata"]

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -189,3 +189,98 @@ class TestConversionRoundtrip:
         # This test verifies the data is preserved in the pyfar representation
         assert pyfar_result["impulse_response"].time.shape == sofa_object.Data_IR.shape
         assert pyfar_result["impulse_response"].sampling_rate == sofa_object.Data_SamplingRate
+
+
+class TestConversionEdgeCases:
+    """Tests for edge cases in conversion methods that would have caught the bug."""
+
+    def test_pyfar_with_3d_receiver_position(self):
+        """Test _to_pyfar with 3D ReceiverPosition array (like FABIAN dataset).
+        
+        This would have caught the original bug where 3D coordinate arrays
+        with shape (N, 3, 1) caused unpacking errors.
+        """
+        import pyfar as pf
+        
+        # Create SOFA object with 3D ReceiverPosition (shape: N, 3, 1)
+        sofa = sf.Sofa("GeneralFIR")
+        sofa.Data_IR = np.random.randn(2, 2, 256).astype(np.float32)
+        sofa.Data_SamplingRate = 44100
+        sofa.SourcePosition = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float64)  # Shape: (2, 3)
+        sofa.ReceiverPosition = np.array([[[0.0], [0.5], [0.0]], [[0.0], [-0.5], [0.0]]], dtype=np.float64)  # Shape: (2, 3, 1)
+        sofa.Data_Delay = np.zeros(2, dtype=np.float32)
+        
+        # This should not raise ValueError about shape mismatch
+        result = test_dataset._to_pyfar(sofa)
+        
+        assert isinstance(result["receiver_coordinates"], pf.Coordinates)
+        assert result["receiver_coordinates"].cshape == (2,)  # Should have 2 receivers
+
+    def test_pyfar_with_3d_source_position(self):
+        """Test _to_pyfar with 3D SourcePosition array.
+        
+        Ensures both source and receiver 3D arrays are handled.
+        """
+        import pyfar as pf
+        
+        # Create SOFA object with 3D SourcePosition (shape: N, 3, 1)
+        sofa = sf.Sofa("GeneralFIR")
+        sofa.Data_IR = np.random.randn(2, 2, 256).astype(np.float32)
+        sofa.Data_SamplingRate = 44100
+        sofa.SourcePosition = np.array([[[0.0], [0.0], [0.0]], [[1.0], [0.0], [0.0]]], dtype=np.float64)  # Shape: (2, 3, 1)
+        sofa.ReceiverPosition = np.array([[0.0, 0.5, 0.0], [0.0, -0.5, 0.0]], dtype=np.float64)  # Shape: (2, 3)
+        sofa.Data_Delay = np.zeros(2, dtype=np.float32)
+        
+        result = test_dataset._to_pyfar(sofa)
+        
+        assert isinstance(result["source_coordinates"], pf.Coordinates)
+        assert result["source_coordinates"].cshape == (2,)  # Should have 2 sources
+
+    def test_pyfar_with_2d_sampling_rate_array(self):
+        """Test _to_pyfar with 2D Data_SamplingRate array (like MIRACLE/SRIRACHA datasets).
+        
+        This would have caught the bug where multi-dimensional sampling rate
+        arrays caused broadcasting errors in pyfar.Signal.
+        """
+        # Create SOFA object with 2D sampling rate array
+        sofa = sf.Sofa("GeneralFIR")
+        sofa.Data_IR = np.random.randn(2, 2, 256).astype(np.float32)
+        sofa.Data_SamplingRate = np.array([[44100, 44100]])  # Shape: (1, 2)
+        sofa.SourcePosition = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float64)
+        sofa.ReceiverPosition = np.array([[0.0, 0.5, 0.0], [0.0, -0.5, 0.0]], dtype=np.float64)
+        sofa.Data_Delay = np.zeros(2, dtype=np.float32)
+        
+        # This should not raise ValueError about broadcasting
+        result = test_dataset._to_pyfar(sofa)
+        
+        # Should extract scalar sampling rate from the array
+        assert result["impulse_response"].sampling_rate == 44100
+
+    def test_pyfar_with_varying_sampling_rates_warns(self):
+        """Test that _to_pyfar warns when multiple different sampling rates are found.
+        
+        Ensures user is notified when data may be inconsistent.
+        """
+        import warnings
+        
+        # Create SOFA object with varying sampling rates
+        sofa = sf.Sofa("GeneralFIR")
+        sofa.Data_IR = np.random.randn(2, 2, 256).astype(np.float32)
+        sofa.Data_SamplingRate = np.array([[44100, 48000]])  # Shape: (1, 2) with different rates
+        sofa.SourcePosition = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float64)
+        sofa.ReceiverPosition = np.array([[0.0, 0.5, 0.0], [0.0, -0.5, 0.0]], dtype=np.float64)
+        sofa.Data_Delay = np.zeros(2, dtype=np.float32)
+        
+        # Should raise UserWarning about multiple sampling rates
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = test_dataset._to_pyfar(sofa)
+            
+            assert len(w) == 1
+            assert issubclass(w[0].category, UserWarning)
+            assert "Multiple sampling rates found" in str(w[0].message)
+            assert "44100" in str(w[0].message) or "48000" in str(w[0].message)
+            assert "Using 44100 Hz" in str(w[0].message)  # First unique value is used
+        
+        # Should still use the first unique value
+        assert result["impulse_response"].sampling_rate == 44100

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -196,49 +196,53 @@ class TestConversionEdgeCases:
 
     def test_pyfar_with_3d_receiver_position(self):
         """Test _to_pyfar with 3D ReceiverPosition array (like FABIAN dataset).
-        
+
         This would have caught the original bug where 3D coordinate arrays
         with shape (N, 3, 1) caused unpacking errors.
         """
         import pyfar as pf
-        
+
         # Create SOFA object with 3D ReceiverPosition (shape: N, 3, 1)
         sofa = sf.Sofa("GeneralFIR")
         sofa.Data_IR = np.random.randn(2, 2, 256).astype(np.float32)
         sofa.Data_SamplingRate = 44100
         sofa.SourcePosition = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float64)  # Shape: (2, 3)
-        sofa.ReceiverPosition = np.array([[[0.0], [0.5], [0.0]], [[0.0], [-0.5], [0.0]]], dtype=np.float64)  # Shape: (2, 3, 1)
+        sofa.ReceiverPosition = np.array(
+            [[[0.0], [0.5], [0.0]], [[0.0], [-0.5], [0.0]]], dtype=np.float64
+        )  # Shape: (2, 3, 1)
         sofa.Data_Delay = np.zeros(2, dtype=np.float32)
-        
+
         # This should not raise ValueError about shape mismatch
         result = test_dataset._to_pyfar(sofa)
-        
+
         assert isinstance(result["receiver_coordinates"], pf.Coordinates)
         assert result["receiver_coordinates"].cshape == (2,)  # Should have 2 receivers
 
     def test_pyfar_with_3d_source_position(self):
         """Test _to_pyfar with 3D SourcePosition array.
-        
+
         Ensures both source and receiver 3D arrays are handled.
         """
         import pyfar as pf
-        
+
         # Create SOFA object with 3D SourcePosition (shape: N, 3, 1)
         sofa = sf.Sofa("GeneralFIR")
         sofa.Data_IR = np.random.randn(2, 2, 256).astype(np.float32)
         sofa.Data_SamplingRate = 44100
-        sofa.SourcePosition = np.array([[[0.0], [0.0], [0.0]], [[1.0], [0.0], [0.0]]], dtype=np.float64)  # Shape: (2, 3, 1)
+        sofa.SourcePosition = np.array(
+            [[[0.0], [0.0], [0.0]], [[1.0], [0.0], [0.0]]], dtype=np.float64
+        )  # Shape: (2, 3, 1)
         sofa.ReceiverPosition = np.array([[0.0, 0.5, 0.0], [0.0, -0.5, 0.0]], dtype=np.float64)  # Shape: (2, 3)
         sofa.Data_Delay = np.zeros(2, dtype=np.float32)
-        
+
         result = test_dataset._to_pyfar(sofa)
-        
+
         assert isinstance(result["source_coordinates"], pf.Coordinates)
         assert result["source_coordinates"].cshape == (2,)  # Should have 2 sources
 
     def test_pyfar_with_2d_sampling_rate_array(self):
         """Test _to_pyfar with 2D Data_SamplingRate array (like MIRACLE/SRIRACHA datasets).
-        
+
         This would have caught the bug where multi-dimensional sampling rate
         arrays caused broadcasting errors in pyfar.Signal.
         """
@@ -249,20 +253,20 @@ class TestConversionEdgeCases:
         sofa.SourcePosition = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float64)
         sofa.ReceiverPosition = np.array([[0.0, 0.5, 0.0], [0.0, -0.5, 0.0]], dtype=np.float64)
         sofa.Data_Delay = np.zeros(2, dtype=np.float32)
-        
+
         # This should not raise ValueError about broadcasting
         result = test_dataset._to_pyfar(sofa)
-        
+
         # Should extract scalar sampling rate from the array
         assert result["impulse_response"].sampling_rate == 44100
 
     def test_pyfar_with_varying_sampling_rates_warns(self):
         """Test that _to_pyfar warns when multiple different sampling rates are found.
-        
+
         Ensures user is notified when data may be inconsistent.
         """
         import warnings
-        
+
         # Create SOFA object with varying sampling rates
         sofa = sf.Sofa("GeneralFIR")
         sofa.Data_IR = np.random.randn(2, 2, 256).astype(np.float32)
@@ -270,17 +274,17 @@ class TestConversionEdgeCases:
         sofa.SourcePosition = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float64)
         sofa.ReceiverPosition = np.array([[0.0, 0.5, 0.0], [0.0, -0.5, 0.0]], dtype=np.float64)
         sofa.Data_Delay = np.zeros(2, dtype=np.float32)
-        
+
         # Should raise UserWarning about multiple sampling rates
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = test_dataset._to_pyfar(sofa)
-            
+
             assert len(w) == 1
             assert issubclass(w[0].category, UserWarning)
             assert "Multiple sampling rates found" in str(w[0].message)
             assert "44100" in str(w[0].message) or "48000" in str(w[0].message)
             assert "Using 44100 Hz" in str(w[0].message)  # First unique value is used
-        
+
         # Should still use the first unique value
         assert result["impulse_response"].sampling_rate == 44100


### PR DESCRIPTION
# Summary

Refines the `BaseDataset` pipeline introduced on `restructuring`. The new flow is:

validate_params → _output_path (check for file) → _get_file → ingest → _to_output

## Main changes:

- **`_output_path`**: new method returning the output path (or `None` for in-memory formats). `_get` checks it upfront and short-circuits if the file already exists, replacing the previous `_move_to_export_dir` indirection.
- **`_get_file` replaces `download` + `_process`**: each dataset now owns the full input-side flow (cache check → download → split/extract) in one method, writing directly under `<base>/<DATASET>/`.
- **`raw_format` class attribute**: declares the publisher's native format (`hdf5` for ISTA, `sofa` for FABIAN). `_get` skips `ingest`/`_to_output` whenever the requested format already matches, so `output_format="hdf5"` on MIRACLE and `output_format="sofa"` on FABIAN return the raw file directly.
- **`validate_params` signature**: `(dataset_kwargs: dict)` → `(**dataset_kwargs)`, now also receives `output_format`. This absorbs the previous separate `validate_output_format` hook (e.g. SRIRACHA's raw-vs-dense rule).
- **`_lookup` helper**: centralizes the export-dir-then-cache-dir file search used by every `_get_file`.
- **`_to_hdf5` converter**: added to `BaseDataset` so HDF5 is now a first-class output format for FABIAN as well.
- **CLI**: parameter help-text matched by name instead of position, so the shared `cache_dir`/`export_dir`/`output_format` parameters injected by `__init_subclass__` line up correctly.
- **`utils.py`**: removed `_move_to_export_dir` (obsolete).
- **Bug fixes** along the way
- **Docstrings**: NumPy-style throughout; D-rule lint fixes.

