### PR TITLE
fix permissions of written files

### DIFF
--- a/docs/reference/python_api.rst
+++ b/docs/reference/python_api.rst
@@ -15,7 +15,6 @@ Dataset modules
    akt
    base
    ista
-   sofa
 
 Internal modules
 ----------------

--- a/src/irdl/base.py
+++ b/src/irdl/base.py
@@ -31,7 +31,7 @@ import sofar as sf
 
 from irdl.cache import IRDL_CACHE_DIR
 from irdl.logging import logger
-from irdl.utils import _fits_in_memory
+from irdl.utils import _fits_in_memory, _preserve_permissions
 
 
 class DatasetCategory(StrEnum):
@@ -497,7 +497,7 @@ output_format : str
             "sampling_rate": float(sofa.Data_SamplingRate),
         }
 
-    def _to_sofa(self, sofa: sf.Sofa, ingest_path: Path, output_path: Path) -> Path:  # noqa: ARG002
+    def _to_sofa(self, sofa: sf.Sofa, ingest_path: Path, output_path: Path) -> Path:
         """Write sofar.Sofa to file and return Path.
 
         Parameters
@@ -516,9 +516,10 @@ output_format : str
         """
         output_path.parent.mkdir(parents=True, exist_ok=True)
         sf.write_sofa(output_path, sofa)
+        _preserve_permissions(ingest_path, output_path)
         return output_path
 
-    def _to_hdf5(self, sofa: sf.Sofa, ingest_path: Path, output_path: Path) -> Path:  # noqa: ARG002
+    def _to_hdf5(self, sofa: sf.Sofa, ingest_path: Path, output_path: Path) -> Path:
         """Convert sofar.Sofa to HDF5 file and return Path.
 
         Parameters
@@ -559,6 +560,7 @@ output_format : str
             if hasattr(sofa, "Humidity"):
                 meta_group.create_dataset("humidity", data=sofa.Humidity)
 
+        _preserve_permissions(ingest_path, output_path)
         return output_path
 
 

--- a/src/irdl/ista.py
+++ b/src/irdl/ista.py
@@ -13,6 +13,7 @@ import sofar as sf
 from irdl.base import BaseDataset, DatasetCategory
 from irdl.downloader import _fetch, _pooch_from_doi
 from irdl.logging import logger
+from irdl.utils import _preserve_permissions
 
 
 class IstaBaseDataset(BaseDataset):
@@ -344,6 +345,7 @@ class MiracleDataset(IstaBaseDataset):
             if "humidity" in data:
                 metadata_group.create_dataset("humidity", data=data["humidity"])
 
+        _preserve_permissions(ingest_path, output_path)
         return output_path
 
 
@@ -591,6 +593,8 @@ class SrirachaDataset(IstaBaseDataset):
             finally:
                 for fh in handles.values():
                     fh.close()
+
+            _preserve_permissions(split_files["C1"], ingest_path)
 
             # delete split files from provider directory
             for f in split_files.values():

--- a/src/irdl/utils.py
+++ b/src/irdl/utils.py
@@ -59,6 +59,19 @@ def _validate_hash_registry(provider_name: str, registry: object) -> None:
             raise ValueError(msg)
 
 
+def _preserve_permissions(source_path: Path, target_path: Path) -> None:
+    """Copy permission bits from one file to another.
+
+    Parameters
+    ----------
+    source_path : Path
+        Existing file whose permission bits should be reused.
+    target_path : Path
+        Existing file that should receive the same permission bits.
+    """
+    target_path.chmod(source_path.stat().st_mode & 0o777)
+
+
 def _fits_in_memory(ingest_path: Path) -> bool:
     """Check if a file can be loaded into available RAM.
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -130,6 +130,17 @@ class TestConversionToSofa:
         assert loaded_sofa.Data_IR.shape == sofa_object.Data_IR.shape
         assert loaded_sofa.Data_SamplingRate == sofa_object.Data_SamplingRate
 
+    def test_conversion_to_sofa_preserves_permissions(self, sofa_object, tmp_path):
+        """Verify _to_sofa reuses the ingest file's permission bits."""
+        ingest_path = tmp_path / "ingest.sofa"
+        ingest_path.write_text("source")
+        ingest_path.chmod(0o640)
+
+        output_path = tmp_path / "test.sofa"
+        result = test_dataset._to_sofa(sofa_object, ingest_path, output_path)
+
+        assert result.stat().st_mode & 0o777 == ingest_path.stat().st_mode & 0o777
+
 
 class TestConversionToHdf5:
     """Tests for _to_hdf5 conversion method."""
@@ -174,3 +185,14 @@ class TestConversionToHdf5:
                 assert "temperature" in f["metadata"]
                 assert "humidity" in f["metadata"]
                 assert "c0" in f["metadata"]
+
+    def test_conversion_to_hdf5_preserves_permissions(self, sofa_object, tmp_path):
+        """Verify _to_hdf5 reuses the ingest file's permission bits."""
+        ingest_path = tmp_path / "ingest.h5"
+        ingest_path.write_text("source")
+        ingest_path.chmod(0o640)
+
+        output_path = tmp_path / "test.h5"
+        result = test_dataset._to_hdf5(sofa_object, ingest_path, output_path)
+
+        assert result.stat().st_mode & 0o777 == ingest_path.stat().st_mode & 0o777

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,5 +1,6 @@
 """Tests for Dataset conversion methods."""
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -35,6 +36,16 @@ class TestDataset(BaseDataset):
 
 # Create the TestDataset instance to use for all conversion tests
 test_dataset = TestDataset()
+
+
+def _assert_permissions_preserved(source_path: Path, target_path: Path) -> None:
+    """Assert permission preservation with Windows-compatible semantics."""
+    source_mode = source_path.stat().st_mode & 0o777
+    target_mode = target_path.stat().st_mode & 0o777
+    if os.name == "nt":
+        assert bool(source_mode & 0o200) == bool(target_mode & 0o200)
+    else:
+        assert target_mode == source_mode
 
 
 class TestConversionToPyFar:
@@ -139,7 +150,7 @@ class TestConversionToSofa:
         output_path = tmp_path / "test.sofa"
         result = test_dataset._to_sofa(sofa_object, ingest_path, output_path)
 
-        assert result.stat().st_mode & 0o777 == ingest_path.stat().st_mode & 0o777
+        _assert_permissions_preserved(ingest_path, result)
 
 
 class TestConversionToHdf5:
@@ -195,4 +206,4 @@ class TestConversionToHdf5:
         output_path = tmp_path / "test.h5"
         result = test_dataset._to_hdf5(sofa_object, ingest_path, output_path)
 
-        assert result.stat().st_mode & 0o777 == ingest_path.stat().st_mode & 0o777
+        _assert_permissions_preserved(ingest_path, result)

--- a/tests/test_ista.py
+++ b/tests/test_ista.py
@@ -1,11 +1,21 @@
 """Tests for ISTA-specific file processing helpers."""
 
+import os
 from pathlib import Path
 
 import h5py
 import numpy as np
 
 from irdl.ista import MiracleDataset, SrirachaDataset
+
+
+def _assert_permissions_preserved(source_mode: int, target_path: Path) -> None:
+    """Assert permission preservation with Windows-compatible semantics."""
+    target_mode = target_path.stat().st_mode & 0o777
+    if os.name == "nt":
+        assert bool(source_mode & 0o200) == bool(target_mode & 0o200)
+    else:
+        assert target_mode == source_mode
 
 
 def _write_ista_hdf5(path: Path, *, n_sources: int, start: int = 0) -> None:
@@ -42,7 +52,7 @@ class TestMiracleProcessing:
         output_path = tmp_path / "ingest" / "A1-C1.h5"
         result = dataset._extract_split(provider_artifact, "C1", output_path)
 
-        assert result.stat().st_mode & 0o777 == provider_artifact.stat().st_mode & 0o777
+        _assert_permissions_preserved(provider_artifact.stat().st_mode & 0o777, result)
 
 
 class TestSrirachaProcessing:
@@ -54,14 +64,19 @@ class TestSrirachaProcessing:
         provider_dir = tmp_path / "provider"
         provider_dir.mkdir()
 
+        first_split_path = None
         for index, split in enumerate(("C1", "C2", "C3", "C4")):
             split_path = provider_dir / f"SR1-{split}.h5"
             _write_ista_hdf5(split_path, n_sources=1, start=index * 100)
             split_path.chmod(0o640)
+            if first_split_path is None:
+                first_split_path = split_path
 
+        assert first_split_path is not None
+        source_mode = first_split_path.stat().st_mode & 0o777
         ingest_path = tmp_path / "ingest" / "SR1.h5"
         ingest_path.parent.mkdir()
         result = dataset._merge_split_files("SR1", provider_dir, ingest_path)
 
-        assert result.stat().st_mode & 0o777 == 0o640  # noqa: PLR2004
+        _assert_permissions_preserved(source_mode, result)
         assert not any(provider_dir.glob("SR1-C*.h5"))

--- a/tests/test_ista.py
+++ b/tests/test_ista.py
@@ -1,0 +1,67 @@
+"""Tests for ISTA-specific file processing helpers."""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from irdl.ista import MiracleDataset, SrirachaDataset
+
+
+def _write_ista_hdf5(path: Path, *, n_sources: int, start: int = 0) -> None:
+    """Write a minimal ISTA-style HDF5 file for processing tests."""
+    impulse_response = np.arange(start, start + n_sources * 2 * 8, dtype=np.float32).reshape(n_sources, 2, 8)
+    source_coordinates = np.arange(start, start + n_sources * 3, dtype=np.float64).reshape(n_sources, 3)
+    receiver_coordinates = np.array([[0.0, 0.5, 0.0], [0.0, -0.5, 0.0]], dtype=np.float64)
+    c0 = np.full(n_sources, 343.0, dtype=np.float32)
+    temperature = np.full(n_sources, 20.0, dtype=np.float32)
+
+    with h5py.File(path, "w") as handle:
+        data_group = handle.create_group("data")
+        data_group.create_dataset("impulse_response", data=impulse_response)
+        location_group = data_group.create_group("location")
+        location_group.create_dataset("source", data=source_coordinates)
+        location_group.create_dataset("receiver", data=receiver_coordinates)
+
+        metadata_group = handle.create_group("metadata")
+        metadata_group.create_dataset("sampling_rate", data=44100)
+        metadata_group.create_dataset("c0", data=c0)
+        metadata_group.create_dataset("temperature", data=temperature)
+
+
+class TestMiracleProcessing:
+    """Tests for MIRACLE-specific processing helpers."""
+
+    def test_extract_split_preserves_permissions(self, tmp_path):
+        """Verify extracted split files reuse the source file's permission bits."""
+        dataset = MiracleDataset()
+        provider_artifact = tmp_path / "A1.h5"
+        _write_ista_hdf5(provider_artifact, n_sources=4)
+        provider_artifact.chmod(0o640)
+
+        output_path = tmp_path / "ingest" / "A1-C1.h5"
+        result = dataset._extract_split(provider_artifact, "C1", output_path)
+
+        assert result.stat().st_mode & 0o777 == provider_artifact.stat().st_mode & 0o777
+
+
+class TestSrirachaProcessing:
+    """Tests for SRIRACHA-specific processing helpers."""
+
+    def test_merge_split_files_preserves_permissions(self, tmp_path):
+        """Verify merged ingest files reuse the split file's permission bits."""
+        dataset = SrirachaDataset()
+        provider_dir = tmp_path / "provider"
+        provider_dir.mkdir()
+
+        for index, split in enumerate(("C1", "C2", "C3", "C4")):
+            split_path = provider_dir / f"SR1-{split}.h5"
+            _write_ista_hdf5(split_path, n_sources=1, start=index * 100)
+            split_path.chmod(0o640)
+
+        ingest_path = tmp_path / "ingest" / "SR1.h5"
+        ingest_path.parent.mkdir()
+        result = dataset._merge_split_files("SR1", provider_dir, ingest_path)
+
+        assert result.stat().st_mode & 0o777 == 0o640  # noqa: PLR2004
+        assert not any(provider_dir.glob("SR1-C*.h5"))


### PR DESCRIPTION
I noticed that some permissions get lost for converted or merged files. This should fix this, copying the permissions of the provider stage (at least on Unix).